### PR TITLE
Add storybook viewport addon

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,7 @@ const config: StorybookConfig = {
         postCss: true,
       },
     },
+    '@storybook/addon-viewport',
   ],
   framework: {
     name: '@storybook/nextjs',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const queryClient = new QueryClient();
 
 import '../src/styles/globals.css';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 // Initialize MSW
 initialize();
@@ -38,6 +39,12 @@ const preview: Preview = {
       };
 
       return config;
+    },
+  },
+  parameters: {
+    viewport: {
+      viewports: INITIAL_VIEWPORTS,
+      defaultViewport: 'iphone6',
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@storybook/addon-interactions": "^7.0.14",
     "@storybook/addon-links": "^7.0.14",
     "@storybook/addon-styling": "^1.0.8",
+    "@storybook/addon-viewport": "^7.0.18",
     "@storybook/blocks": "^7.0.14",
     "@storybook/nextjs": "^7.0.14",
     "@storybook/react": "^7.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@tanstack/react-query':
@@ -72,6 +76,9 @@ devDependencies:
   '@storybook/addon-styling':
     specifier: ^1.0.8
     version: 1.0.8(less@4.1.3)(postcss@8.4.23)(react-dom@18.2.0)(react@18.2.0)(webpack@5.83.1)
+  '@storybook/addon-viewport':
+    specifier: ^7.0.18
+    version: 7.0.18(react-dom@18.2.0)(react@18.2.0)
   '@storybook/blocks':
     specifier: ^7.0.14
     version: 7.0.14(react-dom@18.2.0)(react@18.2.0)
@@ -2475,6 +2482,30 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
+  /@storybook/addon-viewport@7.0.18(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-aVVLBsWXfGDX3z1pc93LWWdG5RUoJbGL/JJPMZGwXdwWpP8V3OBl8D8bgPymyg+MgwhSRZZDDGgnJaVGGwZ6bQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/client-logger': 7.0.18
+      '@storybook/components': 7.0.18(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/core-events': 7.0.18
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 7.0.18(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/preview-api': 7.0.18
+      '@storybook/theming': 7.0.18(react-dom@18.2.0)(react@18.2.0)
+      memoizerific: 1.11.3
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
   /@storybook/addons@7.0.14(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-r/bBBMaJTFC/f/AAZR9NPiTGsb+ScllhzrvBEA7nfAOFg0Vv4m6h2fsysSM+htT7mFwp9gjqB8fFPeJZjS+UKA==}
     peerDependencies:
@@ -2638,6 +2669,17 @@ packages:
       telejson: 7.1.0
     dev: true
 
+  /@storybook/channel-postmessage@7.0.18:
+    resolution: {integrity: sha512-rpwBH5ANdPnugS6+7xG9qHSoS+aPSEnBxDKsONWFubfMTTXQuFkf/793rBbxGkoINdqh8kSdKOM2rIty6e9cmQ==}
+    dependencies:
+      '@storybook/channels': 7.0.18
+      '@storybook/client-logger': 7.0.18
+      '@storybook/core-events': 7.0.18
+      '@storybook/global': 5.0.0
+      qs: 6.11.2
+      telejson: 7.1.0
+    dev: true
+
   /@storybook/channel-websocket@7.0.14:
     resolution: {integrity: sha512-j610zCVWkNDTROOBVgwvrKoPXVWsbfdoMegIXgg+h9jWGWMXRPohtxeauhHICxms3dEYHngH9VI4XVzMmSCXtA==}
     dependencies:
@@ -2649,6 +2691,10 @@ packages:
 
   /@storybook/channels@7.0.14:
     resolution: {integrity: sha512-LVoFy2TRJz5lbIFfaQ6Hapn0XmtXV/kkBbD/kQ9E8KTMfbWlZApGVaCnzGKR7/eiwft38smT9mmyWOfg3CfQbg==}
+
+  /@storybook/channels@7.0.18:
+    resolution: {integrity: sha512-rkA7ea0M3+dWS+71iHJdiZ5R2QuIdiVg0CgyLJHDagc1qej7pEVNhMWtppeq+X5Pwp9nkz8ZTQ7aCjTf6th0/A==}
+    dev: true
 
   /@storybook/cli@7.0.14:
     resolution: {integrity: sha512-x6KP/3i5LPIk/lSPqC7Nx8ikwkSFSPYP51TlWi/ldoCiPmS63MLnRvaDK+zxhy++fk4r9OWKTETptRjw0i6GSg==}
@@ -2713,6 +2759,12 @@ packages:
       '@storybook/global': 5.0.0
     dev: true
 
+  /@storybook/client-logger@7.0.18:
+    resolution: {integrity: sha512-uKgFdVedYoRDZBVrE1IBdWNHDFln1IxWEeI+7ZiNSQwREG9swHpU5Fa8DceclM/oLjJRuzG1jFzv+XZY8894+Q==}
+    dependencies:
+      '@storybook/global': 5.0.0
+    dev: true
+
   /@storybook/codemod@7.0.14:
     resolution: {integrity: sha512-Lw1wJA0wGLnSE10hcBVOtbLVzdgR8uKoOWa1vIpioIBiWyv3/is/D5cEBz8557fCfgCosooJNIdj5emmyHUsgQ==}
     dependencies:
@@ -2744,6 +2796,24 @@ packages:
       '@storybook/global': 5.0.0
       '@storybook/theming': 7.0.14(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.14
+      memoizerific: 1.11.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      use-resize-observer: 9.1.0(react-dom@18.2.0)(react@18.2.0)
+      util-deprecate: 1.0.2
+    dev: true
+
+  /@storybook/components@7.0.18(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Jn1CbF9UAKt8BVaZtuhmthpcZ02VMaCFXR0ISfDXCpiMKnylmpP0+WfXcoKLzz6yS+EW8EW5S9+Qq8xgQY8H7A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 7.0.18
+      '@storybook/csf': 0.1.0
+      '@storybook/global': 5.0.0
+      '@storybook/theming': 7.0.18(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/types': 7.0.18
       memoizerific: 1.11.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -2786,6 +2856,10 @@ packages:
 
   /@storybook/core-events@7.0.14:
     resolution: {integrity: sha512-zHqeRLyL2PasZljLgclDox4cZ/2wN3KZmJJT6VI6VovHe4mr82Jb9PTsuwVwznDyf12em6C9YULgtoCXh5N9Sw==}
+    dev: true
+
+  /@storybook/core-events@7.0.18:
+    resolution: {integrity: sha512-7gxHBQDezdKOeq/u1LL80Bwjfcwsv7XOS3yWQElcgqp+gLaYB6OwwgtkCB2yV6a6l4nep9IdPWE8G3TxIzn9xw==}
     dev: true
 
   /@storybook/core-server@7.0.14:
@@ -2933,6 +3007,31 @@ packages:
       '@storybook/router': 7.0.14(react-dom@18.2.0)(react@18.2.0)
       '@storybook/theming': 7.0.14(react-dom@18.2.0)(react@18.2.0)
       '@storybook/types': 7.0.14
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      semver: 7.5.1
+      store2: 2.14.2
+      telejson: 7.1.0
+      ts-dedent: 2.2.0
+    dev: true
+
+  /@storybook/manager-api@7.0.18(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-anQkm09twL96YkKGXHa+LI0+yMaY6Jxs1lRaetHdMlIqN4VHBHhizHaMgtGfH6xCTuO3WdrKTN7cZii5RH7PBQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/channels': 7.0.18
+      '@storybook/client-logger': 7.0.18
+      '@storybook/core-events': 7.0.18
+      '@storybook/csf': 0.1.0
+      '@storybook/global': 5.0.0
+      '@storybook/router': 7.0.18(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/theming': 7.0.18(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/types': 7.0.18
       dequal: 2.0.3
       lodash: 4.17.21
       memoizerific: 1.11.3
@@ -3118,6 +3217,26 @@ packages:
       util-deprecate: 1.0.2
     dev: true
 
+  /@storybook/preview-api@7.0.18:
+    resolution: {integrity: sha512-xxtC0gPGMn/DbwvS4ZuJaBwfFNsjUCf0yLYHFrNe6fxncbvcLZ550RuyUwYuIRfsiKrlgfa3QmmCa4JM/JesHQ==}
+    dependencies:
+      '@storybook/channel-postmessage': 7.0.18
+      '@storybook/channels': 7.0.18
+      '@storybook/client-logger': 7.0.18
+      '@storybook/core-events': 7.0.18
+      '@storybook/csf': 0.1.0
+      '@storybook/global': 5.0.0
+      '@storybook/types': 7.0.18
+      '@types/qs': 6.9.7
+      dequal: 2.0.3
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      synchronous-promise: 2.0.17
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
   /@storybook/preview@7.0.14:
     resolution: {integrity: sha512-4BfDwtwB4zRKsH+bKLHS5XEcm/EmKgfOaLhzCtDRH9dtGre4OjqU0IMxirdpp7HGNTa8lVgXIwU3F3aVx2Kgfg==}
     dev: true
@@ -3203,6 +3322,19 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
+  /@storybook/router@7.0.18(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-Mue4s/BnKgdYcsiW9yuvW3qL9k3AgYn5HIhnkBExAteyiUGdAca4IJFhArmGgFktgeLc4ecBQ7sgaCljApnbgg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@storybook/client-logger': 7.0.18
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
   /@storybook/store@7.0.14:
     resolution: {integrity: sha512-a4pRSz+55mvdbOm/XDRZQ88Vkerk2fFRomU0W9jgM9Ji5HPTIKOuys3S1wTW7Kl/c3LefHmH+3xZk4b5xfQoPg==}
     dependencies:
@@ -3251,6 +3383,20 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
+  /@storybook/theming@7.0.18(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-P1gMKa/mKQHIMq0sxBIwTzAcF6v/6hrc62YmkuV62vXu+8zNV2YWbRwywqm3Q6faZEadmb/bL9+z8whaKhCL/g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
+      '@storybook/client-logger': 7.0.18
+      '@storybook/global': 5.0.0
+      memoizerific: 1.11.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
   /@storybook/types@7.0.14:
     resolution: {integrity: sha512-P9fL9Ha8nQY2uSc/GaCj/N28g8T0soiNWpBzcd61mk58eiCi1jSP7B5hA+jjKhj1eviIBPhwv81ZwnwLWxCtsg==}
     dependencies:
@@ -3258,6 +3404,15 @@ packages:
       '@types/babel__core': 7.20.0
       '@types/express': 4.17.17
       file-system-cache: 2.3.0
+
+  /@storybook/types@7.0.18:
+    resolution: {integrity: sha512-qPop2CbvmX42/BX29YT9jIzW2TlMcMjAE+KCpcKLBiD1oT5DJ1fhMzpe6RW9HkMegkBxjWx54iamN4oHM/pwcQ==}
+    dependencies:
+      '@storybook/channels': 7.0.18
+      '@types/babel__core': 7.20.0
+      '@types/express': 4.17.17
+      file-system-cache: 2.3.0
+    dev: true
 
   /@swc/helpers@0.5.1:
     resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -26,5 +26,6 @@
     margin: 0 auto;
     padding: 0 20px;
     color: rgb(var(--foreground-rgb));
+    white-space: pre-line;
   }
 }


### PR DESCRIPTION
### ⛳️ Task

- storybook viewport addon을 추가합니다.
- global css로 `white-space` 를 추가합니다.

### ⚡️ Test

storybook 모든 story에서 확인하실 수 있습니다.

### 📸 Screenshot
<img width="300" alt="image" src="https://github.com/depromeet/Ding-dong-fe/assets/55529617/67d758cc-48ea-4fc8-a0b8-f44b87a2a8cc">



### 📎 Reference
[Storybook Viewport Addon](https://storybook.js.org/docs/react/essentials/viewport)