### PR TITLE
Refactor: husky lint 명령어 수정

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm lint-staged
+npx lint-staged


### PR DESCRIPTION
### ⛳️ Task

pre-commit husky 명령어를 수정했습니다. 

```diff
- pnpm lint-staged
+ npx lint-staged
```

`pnpm lint`으로 next lint를 실행하거나 `npx lint-staged`로 eslint를 실행했어야하는데, 제가 스크립트를 작성할 때 잘못 작성해서 적용이 안됐나봐요😓 

이제 정상적으로 eslint 에러가 발생할 거에요~

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
