### PR TITLE
Dep69 Add ImagePreview component

### DIFF
--- a/src/components/Icon/CancelIcon.tsx
+++ b/src/components/Icon/CancelIcon.tsx
@@ -1,5 +1,7 @@
 import { SVGProps } from 'react';
 
+import { tw } from '@/utils/tailwind.util';
+
 // TODO: 모든 SVG 아이콘에 필요하니 추상화 작업이 필요하다고 생각해요~ (색상 변경, 크키 변경, 등등)
 type CancelIconProps = SVGProps<SVGSVGElement> & {
   color?: string;
@@ -13,7 +15,7 @@ export const CancelIcon = ({ className, ...rest }: CancelIconProps) => {
       viewBox="0 0 16 16"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={`${className} fill-black`}
+      className={tw('fill-black', className)}
       {...rest}
     >
       <path d="M16 1.4L14.6 0L8 6.6L1.4 0L0 1.4L6.6 8L0 14.6L1.4 16L8 9.4L14.6 16L16 14.6L9.4 8L16 1.4Z" />

--- a/src/modules/IdCardCreation/IdCardCreation.type.ts
+++ b/src/modules/IdCardCreation/IdCardCreation.type.ts
@@ -4,5 +4,5 @@ export type Steps = 'BOARDING' | 'PROFILE' | 'KEYWORD' | 'KEYWORD_CONTENT' | 'CO
 export type IdCardCreationForm = {
   nickname: string;
   aboutMe: string;
-  keywords: { title: string; imageUrl: string; content: string }[];
+  keywords: { title: string; imageUrl: FileList; content: string }[];
 };

--- a/src/modules/IdCardCreation/Step/ImagePreview.client.tsx
+++ b/src/modules/IdCardCreation/Step/ImagePreview.client.tsx
@@ -24,7 +24,11 @@ export const ImagePreview = ({ index }: ImagePreviewProps) => {
 
   return imagePreview ? (
     <div className="relative">
-      <img src={imagePreview} alt="image preview" />
+      <img
+        src={imagePreview}
+        className="mx-auto my-0 max-h-[192px] max-w-[308px] object-contain"
+        alt="image preview"
+      />
       <div className="absolute right-[12px] top-[12px] flex h-[16px] w-[16px]  items-center justify-center rounded-full bg-grey-800">
         <CancelIcon className="block h-[8px] w-[8px] fill-white" />
       </div>

--- a/src/modules/IdCardCreation/Step/ImagePreview.client.tsx
+++ b/src/modules/IdCardCreation/Step/ImagePreview.client.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { IdCardCreationForm } from '@/modules/IdCardCreation/IdCardCreation.type';
+
+type ImagePreviewProps = {
+  index: number;
+};
+
+export const ImagePreview = ({ index }: ImagePreviewProps) => {
+  const { watch } = useFormContext<IdCardCreationForm>();
+  const [imagePreview, setImagePreview] = useState('');
+  const { keywords } = watch();
+  const imageFileList = keywords[index].imageUrl;
+  useEffect(() => {
+    if (imageFileList && imageFileList.length > 0) {
+      const file = imageFileList[0];
+      setImagePreview(URL.createObjectURL(file));
+    }
+  }, [imageFileList]);
+
+  return imagePreview ? <img src={imagePreview} alt="image preview" /> : null;
+};

--- a/src/modules/IdCardCreation/Step/ImagePreview.client.tsx
+++ b/src/modules/IdCardCreation/Step/ImagePreview.client.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { CancelIcon } from '@/components/Icon';
 import { IdCardCreationForm } from '@/modules/IdCardCreation/IdCardCreation.type';
 
 type ImagePreviewProps = {
@@ -21,5 +22,12 @@ export const ImagePreview = ({ index }: ImagePreviewProps) => {
     }
   }, [imageFileList]);
 
-  return imagePreview ? <img src={imagePreview} alt="image preview" /> : null;
+  return imagePreview ? (
+    <div className="relative">
+      <img src={imagePreview} alt="image preview" />
+      <div className="absolute right-[12px] top-[12px] flex h-[16px] w-[16px]  items-center justify-center rounded-full bg-grey-800">
+        <CancelIcon className="block h-[8px] w-[8px] fill-white" />
+      </div>
+    </div>
+  ) : null;
 };

--- a/src/modules/IdCardCreation/Step/KeywordContentStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/KeywordContentStep.client.tsx
@@ -1,20 +1,23 @@
 'use client';
-import { useFieldArray, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
+
+import { ImagePreview } from '@/modules/IdCardCreation/Step/ImagePreview.client';
 
 const title = '나를 소개하는 키워드의\n 설명을 적어주세요!';
 
 export const KeywordContentStep = () => {
-  const { control, register } = useFormContext<Data>();
-  const { fields } = useFieldArray({ name: 'keywords', control });
+  const { register, watch } = useFormContext();
+  const { keywords } = watch();
 
   return (
     <div>
       <h1 className="text-h1">{title}</h1>
       <div>
-        {fields.map((field, index) => {
+        {keywords.map((keyword, index) => {
           return (
-            <div key={field.id}>
-              <div>{field.title}</div>
+            <div key={index}>
+              <div>{keyword.title}</div>
+              <ImagePreview index={index} />
               <textarea {...register(`keywords.${index}.content`)} />
               <label
                 htmlFor={`keywords.${index}.imageUrl`}

--- a/src/modules/IdCardCreation/Step/KeywordContentStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/KeywordContentStep.client.tsx
@@ -1,9 +1,7 @@
 'use client';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 
-import { Data } from '@/modules/IdCardCreation/IdCardSteps';
-
-const title = '이웃 주민에게 자신을 소개할\n 키워드를 적어주세요!';
+const title = '나를 소개하는 키워드의\n 설명을 적어주세요!';
 
 export const KeywordContentStep = () => {
   const { control, register } = useFormContext<Data>();
@@ -12,15 +10,29 @@ export const KeywordContentStep = () => {
   return (
     <div>
       <h1 className="text-h1">{title}</h1>
-      {fields.map((field, index) => {
-        return (
-          <div key={field.id}>
-            <div className="bg-red-100">{field.title}</div>
-            <textarea {...register(`keywords.${index}.content`)} />
-            <input {...register(`keywords.${index}.imageUrl`)} type="file" accept="image/*" />
-          </div>
-        );
-      })}
+      <div>
+        {fields.map((field, index) => {
+          return (
+            <div key={field.id}>
+              <div>{field.title}</div>
+              <textarea {...register(`keywords.${index}.content`)} />
+              <label
+                htmlFor={`keywords.${index}.imageUrl`}
+                className="text-primary font rounded-[12px] border-[0.5px] border-solid border-grey-100 bg-grey-50 px-[6px] pb-[6px] pt-[6px] text-detail text-primary-500"
+              >
+                이미지 변경
+              </label>
+              <input
+                id={`keywords.${index}.imageUrl`}
+                {...register(`keywords.${index}.imageUrl`)}
+                type="file"
+                accept="image/*"
+                className="hidden"
+              />
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### ⛳️ Task

- ImagePreview component를 추가합니다.
- 이미지의 닫기 버튼 스타일을 추가합니다.
- 이미지의 스타일을 추가합니다.
- image input에 대한 label을 추가합니다.
- `useFieldArray` 를 삭제합니다.

### ✍️ Note

전체적인 스타일은 추후 적용할 예정입니다. 로직 위주로 봐주시면 감사하겠습니다.

### ⚡️ Test

[storybook](http://localhost:6006/?path=/story/idcardsteps--default)에서 단계를 따라가면 확인하실 수 있습니다.

### 📸 Screenshot
<img width="374" alt="image" src="https://github.com/depromeet/Ding-dong-fe/assets/55529617/fa046d3b-f9ed-4663-94f6-9f02f83b46e5">


### 📎 Reference
[Figma](https://www.figma.com/file/TqXqE20VX7V1sw71TYj8qO/DD-_-WIRE-FRAME?type=design&node-id=211-3457&t=lHf4qHpI4Td6xDmA-4)