### PR TITLE
Dep 80 fe id cards list

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.43.9",
+    "react-intersection-observer": "^9.4.4",
     "server-only": "^0.0.1",
     "swiper": "^9.3.2",
     "tailwind-merge": "^1.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ dependencies:
   react-hook-form:
     specifier: ^7.43.9
     version: 7.43.9(react@18.2.0)
+  react-intersection-observer:
+    specifier: ^9.4.4
+    version: 9.4.4(react@18.2.0)
   server-only:
     specifier: ^0.0.1
     version: 0.0.1
@@ -9222,6 +9225,14 @@ packages:
     dependencies:
       react: 18.2.0
     dev: true
+
+  /react-intersection-observer@9.4.4(react@18.2.0):
+    resolution: {integrity: sha512-KQr8ezJscRSQZR0/TjogG4mZttCzdPZj8fhDzAK+xrPYOVvFjabRNy+4EY3UhS3fJaJyIedGjA8y4yKX+nc08w==}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}

--- a/src/app/communities/[id]/layout.tsx
+++ b/src/app/communities/[id]/layout.tsx
@@ -1,0 +1,7 @@
+import { PropsWithChildren } from 'react';
+
+const Layout = ({ children }: PropsWithChildren) => {
+  return <div className="p-[27px]">{children}</div>;
+};
+
+export default Layout;

--- a/src/app/communities/[id]/page.tsx
+++ b/src/app/communities/[id]/page.tsx
@@ -8,13 +8,10 @@ import getQueryClient from '@/lib/tanstackQuery/getQueryClient';
 import { CommunityIdCards } from '@/modules/CommnuityIdCards';
 
 const page = async () => {
-  console.log('page');
   const queryClient = getQueryClient();
   // TODO: 커뮤니티 id 값 수정해야함
   await queryClient.prefetchQuery(community.idCards('1', 1), () => {
-    console.log('prefetchQuery');
     return communityApi.getCommunityIdCards('1', 1).then(data => {
-      console.log(data);
       return {
         pages: [data],
       };

--- a/src/app/communities/[id]/page.tsx
+++ b/src/app/communities/[id]/page.tsx
@@ -1,13 +1,34 @@
 import 'server-only';
 
+import { dehydrate, Hydrate } from '@tanstack/react-query';
+
+import { community } from '@/hooks/api/queryKey.type';
+import communityApi from '@/lib/api/domain/community.api';
+import getQueryClient from '@/lib/tanstackQuery/getQueryClient';
 import { CommunityIdCards } from '@/modules/CommnuityIdCards';
 
-const page = () => {
+const page = async () => {
+  console.log('page');
+  const queryClient = getQueryClient();
+  // TODO: 커뮤니티 id 값 수정해야함
+  await queryClient.prefetchQuery(community.idCards('1', 1), () => {
+    console.log('prefetchQuery');
+    return communityApi.getCommunityIdCards('1', 1).then(data => {
+      console.log(data);
+      return {
+        pages: [data],
+      };
+    });
+  });
+  const dehydratedState = dehydrate(queryClient);
+
   return (
-    <div>
-      <h3 className="mb-16pxr text-h3 text-grey-800">{'우리 행성 주민을 소개할게요!'}</h3>
-      <CommunityIdCards />
-    </div>
+    <Hydrate state={dehydratedState}>
+      <div>
+        <h3 className="mb-16pxr text-h3 text-grey-800">{'우리 행성 주민을 소개할게요!'}</h3>
+        <CommunityIdCards />
+      </div>
+    </Hydrate>
   );
 };
 

--- a/src/app/communities/[id]/page.tsx
+++ b/src/app/communities/[id]/page.tsx
@@ -1,0 +1,14 @@
+import 'server-only';
+
+import { CommunityIdCards } from '@/modules/CommnuityIdCards';
+
+const page = () => {
+  return (
+    <div>
+      <h3 className="mb-16pxr text-h3 text-grey-800">{'우리 행성 주민을 소개할게요!'}</h3>
+      <CommunityIdCards />
+    </div>
+  );
+};
+
+export default page;

--- a/src/hooks/api/community.query.ts
+++ b/src/hooks/api/community.query.ts
@@ -14,6 +14,7 @@ export const useGetCommunityIdCards = ({ id, pageParam }: ComunityIdCardsRequest
           ? data.data.communityIdCardsDtos.page + 1
           : undefined,
       refetchOnWindowFocus: false,
+      enabled: false,
     },
   );
 };

--- a/src/hooks/api/community.query.ts
+++ b/src/hooks/api/community.query.ts
@@ -1,0 +1,19 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { community } from '@/hooks/api/queryKey.type';
+import communityApi from '@/lib/api/domain/community.api';
+import { ComunityIdCardsRequest } from '@/types/community/request.type';
+
+export const useGetCommunityIdCards = ({ id, pageParam }: ComunityIdCardsRequest) => {
+  return useInfiniteQuery(
+    community.idCards(id, pageParam),
+    ({ pageParam = 0 }) => communityApi.getCommunityIdCards(id, pageParam),
+    {
+      getNextPageParam: data =>
+        !data.data.communityIdCardsDtos.hasNext
+          ? data.data.communityIdCardsDtos.page + 1
+          : undefined,
+      refetchOnWindowFocus: false,
+    },
+  );
+};

--- a/src/hooks/api/community.query.ts
+++ b/src/hooks/api/community.query.ts
@@ -12,6 +12,7 @@ export const useGetCommunityIdCards = ({ id, pageParam }: ComunityIdCardsRequest
       getNextPageParam: data =>
         !data.communityIdCardsDtos.hasNext ? data.communityIdCardsDtos.page + 1 : undefined,
       refetchOnWindowFocus: false,
+      //NOTE: 서버컴포넌트에서 이미 1페이지를 데이터 fetch 했기 때문에 2페이지 부터 fetch 하기 위함입니다.
       enabled: false,
     },
   );

--- a/src/hooks/api/community.query.ts
+++ b/src/hooks/api/community.query.ts
@@ -10,9 +10,7 @@ export const useGetCommunityIdCards = ({ id, pageParam }: ComunityIdCardsRequest
     ({ pageParam = 0 }) => communityApi.getCommunityIdCards(id, pageParam),
     {
       getNextPageParam: data =>
-        !data.data.communityIdCardsDtos.hasNext
-          ? data.data.communityIdCardsDtos.page + 1
-          : undefined,
+        !data.communityIdCardsDtos.hasNext ? data.communityIdCardsDtos.page + 1 : undefined,
       refetchOnWindowFocus: false,
       enabled: false,
     },

--- a/src/hooks/api/queryKey.type.ts
+++ b/src/hooks/api/queryKey.type.ts
@@ -1,0 +1,3 @@
+export const community = {
+  idCards: (id: string, pageParam: number) => ['getCommunityIdCards', id, pageParam],
+};

--- a/src/lib/api/domain/community.api.ts
+++ b/src/lib/api/domain/community.api.ts
@@ -1,0 +1,14 @@
+import { BaseResponseType } from '@/lib/api/config/api.types';
+import publicApi from '@/lib/api/config/publicApi';
+import { CommunityIdCardsResponse } from '@/types/community';
+
+const getCommunityIdCards = (id: string, page: number, size: number) =>
+  publicApi.get<BaseResponseType<CommunityIdCardsResponse>>(
+    `/communities/${id}/idCards&page=${page}&size=${size}`,
+  );
+
+const communityApi = {
+  getCommunityIdCards,
+};
+
+export default communityApi;

--- a/src/lib/api/domain/community.api.ts
+++ b/src/lib/api/domain/community.api.ts
@@ -2,10 +2,15 @@ import { BaseResponseType } from '@/lib/api/config/api.types';
 import publicApi from '@/lib/api/config/publicApi';
 import { CommunityIdCardsResponse } from '@/types/community';
 
-const getCommunityIdCards = (id: string, pageParam: number) =>
-  publicApi.get<BaseResponseType<CommunityIdCardsResponse>>(
-    `/communities/${id}/idCards?page=${pageParam}&size=10`,
-  );
+const getCommunityIdCards = async (id: string, pageParam: number) => {
+  const res = await publicApi
+    .get<BaseResponseType<CommunityIdCardsResponse>>(
+      `/communities/${id}/idCards?page=${pageParam}&size=10`,
+    )
+    .then(res => res.data)
+    .catch(err => err.response.data);
+  return res;
+};
 
 const communityApi = {
   getCommunityIdCards,

--- a/src/lib/api/domain/community.api.ts
+++ b/src/lib/api/domain/community.api.ts
@@ -2,9 +2,9 @@ import { BaseResponseType } from '@/lib/api/config/api.types';
 import publicApi from '@/lib/api/config/publicApi';
 import { CommunityIdCardsResponse } from '@/types/community';
 
-const getCommunityIdCards = (id: string, page: number, size: number) =>
+const getCommunityIdCards = (id: string, pageParam: number) =>
   publicApi.get<BaseResponseType<CommunityIdCardsResponse>>(
-    `/communities/${id}/idCards&page=${page}&size=${size}`,
+    `/communities/${id}/idCards?page=${pageParam}&size=10`,
   );
 
 const communityApi = {

--- a/src/lib/tanstackQuery/getQueryClient.tsx
+++ b/src/lib/tanstackQuery/getQueryClient.tsx
@@ -1,0 +1,5 @@
+import { QueryClient } from '@tanstack/react-query';
+import { cache } from 'react';
+
+const getQueryClient = cache(() => new QueryClient());
+export default getQueryClient;

--- a/src/mocks/community/community.mock.ts
+++ b/src/mocks/community/community.mock.ts
@@ -32,5 +32,5 @@ export const createCommunityIdCards = (
   content: Array.from({ length: n }, (_, idx) => createCommunityIdCard(idx)),
   page,
   size,
-  hasNext: page === 3,
+  hasNext: page === 5,
 });

--- a/src/mocks/community/community.mock.ts
+++ b/src/mocks/community/community.mock.ts
@@ -1,0 +1,36 @@
+import { faker } from '@faker-js/faker/locale/ko';
+
+import { SliceResponse } from '@/types/api';
+import { CommunityIdCardsModel } from '@/types/community';
+
+export const createCommunityIdCard = (idx: number): CommunityIdCardsModel => ({
+  idCardId: idx,
+  nickname: faker.person.fullName(),
+  aboutMe: faker.lorem.paragraph(),
+  characterType: faker.helpers.arrayElement(['TRUE', 'PIPI', 'TOBBY', 'BUDDY']),
+  keywordTitles: faker.helpers.arrayElements(
+    [
+      '르세라핌 최고',
+      '엽떡',
+      '디프만 12기',
+      '디프만 운영진',
+      'FE 3년차',
+      '디자이너',
+      '축구',
+      '피파',
+      '백엔드',
+    ],
+    3,
+  ),
+});
+
+export const createCommunityIdCards = (
+  n: number,
+  page: number,
+  size: number,
+): SliceResponse<CommunityIdCardsModel> => ({
+  content: Array.from({ length: n }, (_, idx) => createCommunityIdCard(idx)),
+  page,
+  size,
+  hasNext: page === 3,
+});

--- a/src/mocks/community/community.mockHandler.ts
+++ b/src/mocks/community/community.mockHandler.ts
@@ -5,15 +5,14 @@ import { createCommunityIdCards } from '@/mocks/community/community.mock';
 
 const communityMockHandler = [
   // GET: api/communities/1/idCards
-  rest.get(`${ROOT_API_URL}/communities/:id/idCards&page=:page&size=:size`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL}/communities/:id/idCards?page=:page&size=10`, (req, res, ctx) => {
     const { searchParams } = req.url;
     const page = Number(searchParams.get('page'));
-    const size = Number(searchParams.get('size'));
 
     return res(
       ctx.status(200),
       ctx.json({
-        communityIdCardsDtos: createCommunityIdCards(10, page, size),
+        communityIdCardsDtos: createCommunityIdCards(10, page, 10),
       }),
     );
   }),

--- a/src/mocks/community/community.mockHandler.ts
+++ b/src/mocks/community/community.mockHandler.ts
@@ -4,8 +4,8 @@ import { ROOT_API_URL } from '@/lib/api/config/requestUrl';
 import { createCommunityIdCards } from '@/mocks/community/community.mock';
 
 const communityMockHandler = [
-  // GET: api/communities/[id]/idCards
-  rest.get(`${ROOT_API_URL}/communities/:id/idCards`, (req, res, ctx) => {
+  // GET: api/communities/1/idCards
+  rest.get(`${ROOT_API_URL}/communities/:id/idCards&page=:page&size=:size`, (req, res, ctx) => {
     const { searchParams } = req.url;
     const page = Number(searchParams.get('page'));
     const size = Number(searchParams.get('size'));
@@ -13,7 +13,7 @@ const communityMockHandler = [
     return res(
       ctx.status(200),
       ctx.json({
-        communityIdCardDtos: createCommunityIdCards(10, page, size),
+        communityIdCardsDtos: createCommunityIdCards(10, page, size),
       }),
     );
   }),

--- a/src/mocks/community/community.mockHandler.ts
+++ b/src/mocks/community/community.mockHandler.ts
@@ -1,0 +1,22 @@
+import { rest } from 'msw';
+
+import { ROOT_API_URL } from '@/lib/api/config/requestUrl';
+import { createCommunityIdCards } from '@/mocks/community/community.mock';
+
+const communityMockHandler = [
+  // GET: api/communities/[id]/idCards
+  rest.get(`${ROOT_API_URL}/communities/:id/idCards`, (req, res, ctx) => {
+    const { searchParams } = req.url;
+    const page = Number(searchParams.get('page'));
+    const size = Number(searchParams.get('size'));
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        communityIdCardDtos: createCommunityIdCards(10, page, size),
+      }),
+    );
+  }),
+];
+
+export default communityMockHandler;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
+import communityMockHandler from '@/mocks/community/community.mockHandler';
 import idCardMockHandler from '@/mocks/idCard/idCard.mockHandler';
 
-const handlers = [...idCardMockHandler];
+const handlers = [...idCardMockHandler, ...communityMockHandler];
 
 export default handlers;

--- a/src/modules/CommnuityIdCards/CommunityIdCards.client.tsx
+++ b/src/modules/CommnuityIdCards/CommunityIdCards.client.tsx
@@ -8,7 +8,6 @@ import { IdCard } from '@/modules/IdCard';
 import { CommunityIdCardsModel } from '@/types/community';
 
 export const CommunityIdCards = () => {
-  console.log('CommunityIdCards');
   // TODO: 커뮤니티 id 값 수정해야함
   const { data: communityIdCards, fetchNextPage } = useGetCommunityIdCards({
     id: '1',
@@ -25,7 +24,7 @@ export const CommunityIdCards = () => {
   return (
     <div className="flex flex-col gap-18pxr">
       {communityIdCards?.pages.map(page => {
-        return page.data?.communityIdCardsDtos.content.map((idCard: CommunityIdCardsModel) => {
+        return page.communityIdCardsDtos.content.map((idCard: CommunityIdCardsModel) => {
           return <IdCard key={idCard.idCardId} {...idCard} />;
         });
       })}

--- a/src/modules/CommnuityIdCards/CommunityIdCards.client.tsx
+++ b/src/modules/CommnuityIdCards/CommunityIdCards.client.tsx
@@ -8,6 +8,7 @@ import { IdCard } from '@/modules/IdCard';
 import { CommunityIdCardsModel } from '@/types/community';
 
 export const CommunityIdCards = () => {
+  console.log('CommunityIdCards');
   // TODO: 커뮤니티 id 값 수정해야함
   const { data: communityIdCards, fetchNextPage } = useGetCommunityIdCards({
     id: '1',

--- a/src/modules/CommnuityIdCards/CommunityIdCards.client.tsx
+++ b/src/modules/CommnuityIdCards/CommunityIdCards.client.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useInView } from 'react-intersection-observer';
+
+import { useGetCommunityIdCards } from '@/hooks/api/community.query';
+import { IdCard } from '@/modules/IdCard';
+import { CommunityIdCardsModel } from '@/types/community';
+
+export const CommunityIdCards = () => {
+  // TODO: 커뮤니티 id 값 수정해야함
+  const { data: communityIdCards, fetchNextPage } = useGetCommunityIdCards({
+    id: '1',
+    pageParam: 1,
+  });
+  const { ref, inView } = useInView();
+
+  useEffect(() => {
+    if (inView && communityIdCards?.pages) {
+      fetchNextPage();
+    }
+  }, [inView, fetchNextPage, communityIdCards?.pages]);
+
+  return (
+    <div className="flex flex-col gap-18pxr">
+      {communityIdCards?.pages.map(page => {
+        return page.data?.communityIdCardsDtos.content.map((idCard: CommunityIdCardsModel) => {
+          return <IdCard key={idCard.idCardId} {...idCard} />;
+        });
+      })}
+      <div ref={ref}></div>
+    </div>
+  );
+};

--- a/src/modules/CommnuityIdCards/index.ts
+++ b/src/modules/CommnuityIdCards/index.ts
@@ -1,0 +1,1 @@
+export * from './CommunityIdCards.client';

--- a/src/types/community/model.type.ts
+++ b/src/types/community/model.type.ts
@@ -1,4 +1,4 @@
-import { IdCardDetailModel } from '@/types/idCard';
+import { CharacterNameModel, IdCardDetailModel } from '@/types/idCard';
 
 export type CommunityIdCardSummaryModel = Omit<IdCardDetailModel, 'profileImageUrl'>;
 
@@ -7,4 +7,12 @@ export type CommunitySummaryModel = {
   thumbnailImageUrl: string;
   coverImageUrl: string;
   title: string;
+};
+
+export type CommunityIdCardsModel = {
+  idCardId: number;
+  nickname: string;
+  aboutMe: string;
+  characterType: CharacterNameModel;
+  keywordTitles: string[];
 };

--- a/src/types/community/request.type.ts
+++ b/src/types/community/request.type.ts
@@ -1,0 +1,4 @@
+export type ComunityIdCardsRequest = {
+  pageParam: number;
+  id: string;
+};

--- a/src/types/community/response.type.ts
+++ b/src/types/community/response.type.ts
@@ -1,9 +1,8 @@
 import { SliceResponse } from '@/types/api';
-import { CommunitySummaryModel } from '@/types/community';
-import { CommunityIdCardSummaryModel } from '@/types/community';
+import { CommunityIdCardsModel, CommunitySummaryModel } from '@/types/community';
 
 export type CommunitiesResponse = CommunitySummaryModel[];
 
 export type CommunityIdCardsResponse = {
-  communityIdCardsDtos: SliceResponse<CommunityIdCardSummaryModel>;
+  communityIdCardsDtos: SliceResponse<CommunityIdCardsModel>;
 };

--- a/src/types/community/response.type.ts
+++ b/src/types/community/response.type.ts
@@ -4,4 +4,6 @@ import { CommunityIdCardSummaryModel } from '@/types/community';
 
 export type CommunitiesResponse = CommunitySummaryModel[];
 
-export type CommunityIdCardsResponse = SliceResponse<CommunityIdCardSummaryModel>;
+export type CommunityIdCardsResponse = {
+  communityIdCardsDtos: SliceResponse<CommunityIdCardSummaryModel>;
+};


### PR DESCRIPTION
### ⛳️ Task
홈에서 주민증 리스트 무한 스크롤링을 구현했어요!

### ✍️ Note
서버 컴포넌트에서 pre-fetch 하여 1페이지만을 보여주고, 클라이언트 컴포넌트로 데이터를 보내 (실제로는 props로 데이터를 보내는 방식이 아닌 react-query 의 Hydrate 요소를 클라이언트 컴포넌트로 래핑해서 클라이언트 컴포넌트에서 사용할 수 있도록 만들어 줍니다.) 무한 스크롤링을 구현하였습니다.

자세한 설명은 코멘트 달아 두겠습니다 ! 

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
