### PR TITLE
Dep 112 id card creation page

### DIFF
--- a/src/app/id-card/create/page.tsx
+++ b/src/app/id-card/create/page.tsx
@@ -1,0 +1,9 @@
+import 'server-only';
+
+import { IdCardCreationSteps } from '~/modules/IdCardCreation';
+
+const IdCardCreationPage = () => {
+  return <IdCardCreationSteps />;
+};
+
+export default IdCardCreationPage;

--- a/src/components/KeywordInput/KeywordInput.tsx
+++ b/src/components/KeywordInput/KeywordInput.tsx
@@ -95,7 +95,7 @@ export const KeywordInput = ({
           />
         </ul>
       </div>
-      <div className="mt-28pxr">
+      <div className="mt-28pxr px-layout-sm">
         <label className="text-b2 text-grey-400">{keywordLabel}</label>
         <ul className="flex flex-wrap gap-x-8pxr gap-y-12pxr py-16pxr">
           {keywordOptions.map(({ title }) => (

--- a/src/modules/IdCardCreation/IdCardCreation.type.ts
+++ b/src/modules/IdCardCreation/IdCardCreation.type.ts
@@ -1,7 +1,1 @@
-export type CreationSteps =
-  | 'LOADING'
-  | 'BOARDING'
-  | 'PROFILE'
-  | 'KEYWORD'
-  | 'KEYWORD_CONTENT'
-  | 'COMPLETE';
+export type CreationSteps = 'BOARDING' | 'PROFILE' | 'KEYWORD' | 'KEYWORD_CONTENT' | 'COMPLETE';

--- a/src/modules/IdCardCreation/IdCardCreationSteps.tsx
+++ b/src/modules/IdCardCreation/IdCardCreationSteps.tsx
@@ -37,7 +37,7 @@ export const IdCardCreationSteps = () => {
   return (
     <FormProvider {...methods}>
       {/* planetName 주입이 필요합니다. */}
-      <div className="px-20pxr">
+      <div>
         {steps[stepOrder] === 'BOARDING' && <BoardingStep planetName="Dingdong" onNext={onNext} />}
         {['PROFILE', 'KEYWORD', 'KEYWORD_CONTENT'].includes(steps[stepOrder]) && (
           <IdCardCreationForm steps={steps} stepOrder={stepOrder} onNext={onNext} onPrev={onPrev} />

--- a/src/modules/IdCardCreation/IdCardCreationSteps.tsx
+++ b/src/modules/IdCardCreation/IdCardCreationSteps.tsx
@@ -1,24 +1,17 @@
 'use client';
 
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import * as yup from 'yup';
 
 import { IdCardCreationForm } from '~/modules/IdCardCreation/Form';
-import { BoardingStep, CompleteStep, LoadingStep } from '~/modules/IdCardCreation/Step';
+import { BoardingStep, CompleteStep } from '~/modules/IdCardCreation/Step';
 import { IdCardCreationFormModel } from '~/types/idCard';
 
 import { CreationSteps } from './IdCardCreation.type';
 
-const steps: CreationSteps[] = [
-  'LOADING',
-  'BOARDING',
-  'PROFILE',
-  'KEYWORD',
-  'KEYWORD_CONTENT',
-  'COMPLETE',
-];
+const steps: CreationSteps[] = ['BOARDING', 'PROFILE', 'KEYWORD', 'KEYWORD_CONTENT', 'COMPLETE'];
 
 const schema = yup.object({
   profileImageUrl: yup.string(),
@@ -41,17 +34,10 @@ export const IdCardCreationSteps = () => {
   const onNext = () => setStepOrder(stepOrder + 1);
   const onPrev = () => setStepOrder(stepOrder - 1);
 
-  useEffect(() => {
-    const loadingShow = setTimeout(() => onNext(), 2000);
-    return () => clearTimeout(loadingShow);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     <FormProvider {...methods}>
       {/* planetName 주입이 필요합니다. */}
       <div className="px-20pxr">
-        {steps[stepOrder] === 'LOADING' && <LoadingStep planetName="Ding dong" />}
         {steps[stepOrder] === 'BOARDING' && <BoardingStep planetName="Dingdong" onNext={onNext} />}
         {['PROFILE', 'KEYWORD', 'KEYWORD_CONTENT'].includes(steps[stepOrder]) && (
           <IdCardCreationForm steps={steps} stepOrder={stepOrder} onNext={onNext} onPrev={onPrev} />

--- a/src/modules/IdCardCreation/Step/BoardingStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/BoardingStep.client.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Image from 'next/image';
 import { ReactNode, useState } from 'react';
 

--- a/src/modules/IdCardCreation/Step/BoardingStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/BoardingStep.client.tsx
@@ -65,7 +65,7 @@ export const BoardingStep = ({ planetName, onNext }: BoardingStepProps) => {
   const bottomSheetContent = subStepBottomSheet[currentIdx];
 
   return (
-    <div>
+    <div className="px-layout-sm">
       <h1 className="mb-16pxr mt-24pxr text-h2 text-grey-900">{planetName}에 온걸 환영해!</h1>
       <Swiper slidesPerView="auto" pagination={{ clickable: true }} allowTouchMove>
         {subStepList.map(({ id, label, image, helperText }) => (

--- a/src/modules/IdCardCreation/Step/CompleteStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/CompleteStep.client.tsx
@@ -15,7 +15,7 @@ export const CompleteStep = () => {
   const keywordTitles = keywords.map((keyword: KeywordModel) => keyword.title);
   return (
     // TODO: 지금은 커뮤니티 정보가 없는데 나중에 커뮤니티 타이틀 추가
-    <div className="flex min-h-[calc(100vh-50px)] flex-col">
+    <div className="flex min-h-[calc(100vh-50px)] flex-col px-layout-sm ">
       <h2 className="text-h1 text-grey-900">{`짜잔!${title} \n주민증이 발급되었어요!`}</h2>
       <div className="mt-24pxr flex flex-1 flex-col">
         <IdCard

--- a/src/modules/IdCardCreation/Step/KeywordContentStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/KeywordContentStep.client.tsx
@@ -11,7 +11,7 @@ export const KeywordContentStep = () => {
   const { keywords } = watch();
 
   return (
-    <div>
+    <div className="px-layout-sm">
       <h1 className="text-h1">{title}</h1>
       <div className="mt-26pxr flex flex-col gap-22pxr">
         {keywords.map((keyword: FormKeywordModel, index: number) => {

--- a/src/modules/IdCardCreation/Step/KeywordStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/KeywordStep.client.tsx
@@ -12,7 +12,7 @@ export const KeywordStep = () => {
 
   return (
     <div>
-      <h1 className="text-h1">{title}</h1>
+      <h1 className="px-layout-sm text-h1">{title}</h1>
       <Controller
         name="keywords"
         control={control}

--- a/src/modules/IdCardCreation/Step/ProfileStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/ProfileStep.client.tsx
@@ -28,7 +28,7 @@ export const ProfileStep = () => {
   });
 
   return (
-    <div>
+    <div className="px-layout-sm">
       <h1 className="text-h1">{title}</h1>
       {/*TODO: 캐릭터 디자인 나오면 faker 삭제 예정*/}
       <ProfileImageEdit<IdCardCreationFormModel>


### PR DESCRIPTION
### ⛳️ Task

- 주민증 생성 페이지(`/id-card/create`)를 만듭니다.
- 로딩 페이지가 spec out 되어 삭제합니다.
- 레이아웃 tailwind 추가된 것에 맞게 수정합니다.

### ✍️ Note

- 스타일 수정이 위주여서 테스트 한 번 돌려보시고 넘어가면 될 것 같습니다!

### ⚡️ Test

[local](http://localhost:3000/id-card/create)에서 테스트할 수 있습니다.


### 📎 Reference
[Figma](https://www.figma.com/file/TqXqE20VX7V1sw71TYj8qO/DD-_-WIRE-FRAME?type=design&node-id=475-6020&t=to63ZDadqhhJtwo0-4)