### PR TITLE
Refactor/fix login api

### DIFF
--- a/src/app/auth/callback/kakao/page.tsx
+++ b/src/app/auth/callback/kakao/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import publicApi from '~/api/config/publicApi';
+import { AuthResponse } from '~/types/auth';
+import { generateCookiesKeyValues } from '~/utils/auth/tokenHandlers';
+
+const KakaoCallbackPage = () => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const code = searchParams.get('code');
+  const { data } = useQuery<AuthResponse>(['login'], async () => {
+    const authData = await publicApi.post<AuthResponse>('/auth/login/kakao', {
+      authCode: code,
+      redirectUri: process.env.KAKAO_REDIRECT_URI,
+    });
+    if (authData.data) {
+      const cookies = generateCookiesKeyValues(authData.data);
+      cookies.forEach(([key, value]) => {
+        document.cookie = `${key}=${value}; path=/;`;
+      });
+      router.replace('/');
+    }
+
+    return authData;
+  });
+  useEffect(() => {
+    if (data?.accessToken) {
+      router.replace('/');
+    }
+  }, [data, router]);
+
+  return <></>;
+};
+
+export default KakaoCallbackPage;

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -1,0 +1,140 @@
+/**
+ * Multi purpose CORS lib.
+ * Note: Based on the `cors` package in npm but using only
+ * web APIs. Feel free to use it in your own projects.
+ */
+
+type StaticOrigin = boolean | string | RegExp | (boolean | string | RegExp)[];
+
+type OriginFn = (origin: string | undefined, req: Request) => StaticOrigin | Promise<StaticOrigin>;
+
+interface CorsOptions {
+  origin?: StaticOrigin | OriginFn;
+  methods?: string | string[];
+  allowedHeaders?: string | string[];
+  exposedHeaders?: string | string[];
+  credentials?: boolean;
+  maxAge?: number;
+  preflightContinue?: boolean;
+  optionsSuccessStatus?: number;
+}
+
+const defaultOptions: CorsOptions = {
+  origin: '*',
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+  preflightContinue: false,
+  optionsSuccessStatus: 204,
+};
+
+function isOriginAllowed(origin: string, allowed: StaticOrigin): boolean {
+  return Array.isArray(allowed)
+    ? allowed.some(o => isOriginAllowed(origin, o))
+    : typeof allowed === 'string'
+    ? origin === allowed
+    : allowed instanceof RegExp
+    ? allowed.test(origin)
+    : !!allowed;
+}
+
+function getOriginHeaders(reqOrigin: string | undefined, origin: StaticOrigin) {
+  const headers = new Headers();
+
+  if (origin === '*') {
+    // Allow any origin
+    headers.set('Access-Control-Allow-Origin', '*');
+  } else if (typeof origin === 'string') {
+    // Fixed origin
+    headers.set('Access-Control-Allow-Origin', origin);
+    headers.append('Vary', 'Origin');
+  } else {
+    const allowed = isOriginAllowed(reqOrigin ?? '', origin);
+
+    if (allowed && reqOrigin) {
+      headers.set('Access-Control-Allow-Origin', reqOrigin);
+    }
+    headers.append('Vary', 'Origin');
+  }
+
+  return headers;
+}
+
+// originHeadersFromReq
+
+async function originHeadersFromReq(req: Request, origin: StaticOrigin | OriginFn) {
+  const reqOrigin = req.headers.get('Origin') || undefined;
+  const value = typeof origin === 'function' ? await origin(reqOrigin, req) : origin;
+
+  if (!value) return;
+  return getOriginHeaders(reqOrigin, value);
+}
+
+function getAllowedHeaders(req: Request, allowed?: string | string[]) {
+  const headers = new Headers();
+
+  if (!allowed) {
+    allowed = req.headers.get('Access-Control-Request-Headers')!;
+    headers.append('Vary', 'Access-Control-Request-Headers');
+  } else if (Array.isArray(allowed)) {
+    // If the allowed headers is an array, turn it into a string
+    allowed = allowed.join(',');
+  }
+  if (allowed) {
+    headers.set('Access-Control-Allow-Headers', allowed);
+  }
+
+  return headers;
+}
+
+export default async function cors(req: Request, res: Response, options?: CorsOptions) {
+  const opts = { ...defaultOptions, ...options };
+  const { headers } = res;
+  const originHeaders = await originHeadersFromReq(req, opts.origin ?? false);
+  const mergeHeaders = (v: string, k: string) => {
+    if (k === 'Vary') headers.append(k, v);
+    else headers.set(k, v);
+  };
+
+  // If there's no origin we won't touch the response
+  if (!originHeaders) return res;
+
+  originHeaders.forEach(mergeHeaders);
+
+  if (opts.credentials) {
+    headers.set('Access-Control-Allow-Credentials', 'true');
+  }
+
+  const exposed = Array.isArray(opts.exposedHeaders)
+    ? opts.exposedHeaders.join(',')
+    : opts.exposedHeaders;
+
+  if (exposed) {
+    headers.set('Access-Control-Expose-Headers', exposed);
+  }
+
+  // Handle the preflight request
+  if (req.method === 'OPTIONS') {
+    if (opts.methods) {
+      const methods = Array.isArray(opts.methods) ? opts.methods.join(',') : opts.methods;
+
+      headers.set('Access-Control-Allow-Methods', methods);
+    }
+
+    getAllowedHeaders(req, opts.allowedHeaders).forEach(mergeHeaders);
+
+    if (typeof opts.maxAge === 'number') {
+      headers.set('Access-Control-Max-Age', String(opts.maxAge));
+    }
+
+    if (opts.preflightContinue) return res;
+
+    headers.set('Content-Length', '0');
+    return new Response(null, { status: opts.optionsSuccessStatus, headers });
+  }
+
+  // If we got here, it's a normal request
+  return res;
+}
+
+export function initCors(options?: CorsOptions) {
+  return (req: Request, res: Response) => cors(req, res, options);
+}


### PR DESCRIPTION
### ⛳️ Task
로컬에서 로그인이 가능하도록 수정했어요.
- middleware에서 서버사이드 로그인을 수행하고, fetch 에러(cors 에러 등) 발생시 클라이언트 로그인을 다시 한번 더 수행하도록 처리했습니다.
- next에서 cors 세팅을 돕는 cors 유틸을 생성했습니다.
- 클라이언트 로그인을 수행하는 카카오 로그인 콜백 페이지를 만들었습니다.
### ✍️ Note
(로컬에서) 서버사이드 로그인을 위해 fetch 수행시, cors 에러가 발생하며 로그인 실패합니다.
- 이경우 클라이언트 로그인을 수행하는 사이트로 보내어 다시 로그인 처리를 수행합니다.
- next에서 cors를 해결하는 방안이 있다고 하는데 현시점까지 정확히 찾지 못했습니다.
- 배포된 사이트는 서버와 origin이 같기 때문에 서버사이드 로그인 수행 가능할것으로 생각됩니다.
- 정확한 원인은 아직 파악중이지만 로그인이 되어야 다른 기능 개발에도 필요하기 때문에 로그인에서 시간을 많이 지체하기 보다는 먼저 기능을 구현하고 추후 수정하는게 나을것 같다고 생각했습니다.
### ⚡️ Test
/auth/signin 에서 로그인 가능합니다.
/auth/signout에서 로그아웃 가능합니다.

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
