### PR TITLE
Dep 73 idcard create api

### DIFF
--- a/src/api/domain/idCard.api.ts
+++ b/src/api/domain/idCard.api.ts
@@ -1,5 +1,22 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
 import privateApi from '~/api/config/privateApi';
-import { IdCardDetailResponse } from '~/types/idCard';
+import { IdCardCreateRequest, IdCardCreateResponse, IdCardDetailResponse } from '~/types/idCard';
 
 export const getIdCardDetail = (idCardId: string) =>
   privateApi.get<IdCardDetailResponse>(`/id-cards/${idCardId}`);
+
+export const postIdCardCreate = (IdCardInfo: IdCardCreateRequest) =>
+  privateApi.post<IdCardCreateResponse>(`/id-cards/create`, IdCardInfo);
+
+export const usePostIdCardCreate = (
+  options?: Omit<
+    UseMutationOptions<IdCardCreateResponse, AxiosError, IdCardCreateRequest>,
+    'mutationFn'
+  >,
+) =>
+  useMutation<IdCardCreateResponse, AxiosError, IdCardCreateRequest>({
+    mutationFn: postIdCardCreate,
+    ...options,
+  });

--- a/src/api/domain/idCard.api.ts
+++ b/src/api/domain/idCard.api.ts
@@ -8,7 +8,7 @@ export const getIdCardDetail = (idCardId: string) =>
   privateApi.get<IdCardDetailResponse>(`/id-cards/${idCardId}`);
 
 export const postIdCardCreate = (IdCardInfo: IdCardCreateRequest) =>
-  privateApi.post<IdCardCreateResponse>(`/id-cards/create`, IdCardInfo);
+  privateApi.post<IdCardCreateResponse>(`/id-cards`, IdCardInfo);
 
 export const usePostIdCardCreate = (
   options?: Omit<

--- a/src/app/my-page/edit/page.tsx
+++ b/src/app/my-page/edit/page.tsx
@@ -1,9 +1,9 @@
-import { createIdCard } from '~/mocks/idCard/idCard.mock';
+import { idCardDetailMock } from '~/mocks/idCard/idCard.mock';
 import { IdCardEditor } from '~/modules/IdCardEditor';
 
 const EditMyPage = () => {
   // TODO: api나오면 수정 예정
-  const idCardDetailsDto = createIdCard();
+  const idCardDetailsDto = idCardDetailMock();
   const { idCardId, nickname, aboutMe, profileImageUrl, keywords } = idCardDetailsDto;
 
   return (

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -3,13 +3,13 @@ import { useRouter } from 'next/navigation';
 
 import { GearFillIcon } from '~/components/Icon';
 import { TopNavigation } from '~/components/TopNavigation';
-import { createIdCard } from '~/mocks/idCard/idCard.mock';
+import { idCardDetailMock } from '~/mocks/idCard/idCard.mock';
 import { IdCard } from '~/modules/IdCard';
 
 const MyPage = () => {
   const router = useRouter();
   // TODO: 해당 행성에서 내 주민증 정보 요청 api 추가 예정
-  const { idCardId, nickname, aboutMe, characterType, keywords } = createIdCard();
+  const { idCardId, nickname, aboutMe, characterType, keywords } = idCardDetailMock();
   const keywordTitles = keywords.map(keyword => keyword.title);
 
   const onClickGearFill = () => {

--- a/src/mocks/community/community.mockHandler.ts
+++ b/src/mocks/community/community.mockHandler.ts
@@ -7,7 +7,7 @@ import {
   createCommunityList,
 } from '~/mocks/community/community.mock';
 
-const communityMockHandler = [
+export const communityMockHandler = [
   rest.get(
     `${ROOT_API_URL}/communities/:communityId/idCards?page=:page&size=10`,
     (req, res, ctx) => {
@@ -31,5 +31,3 @@ const communityMockHandler = [
     return res(ctx.status(200), ctx.json({ communityListDtos: createCommunityList() }));
   }),
 ];
-
-export default communityMockHandler;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,5 @@
-import communityMockHandler from '~/mocks/community/community.mockHandler';
-import idCardMockHandler from '~/mocks/idCard/idCard.mockHandler';
+import { communityMockHandler } from '~/mocks/community/community.mockHandler';
+import { idCardMockHandler } from '~/mocks/idCard/idCard.mockHandler';
 
 const handlers = [...idCardMockHandler, ...communityMockHandler];
 

--- a/src/mocks/idCard/idCard.mock.ts
+++ b/src/mocks/idCard/idCard.mock.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker/locale/ko';
 
-import { IdCardDetailModel } from '~/types/idCard';
+import { IdCardCreateResponse, IdCardDetailModel } from '~/types/idCard';
 
-export const createIdCard = (): IdCardDetailModel => ({
+export const idCardDetailMock = (): IdCardDetailModel => ({
   idCardId: faker.number.int(),
   nickname: faker.person.fullName(),
   profileImageUrl: faker.image.avatar(),
@@ -15,3 +15,5 @@ export const createIdCard = (): IdCardDetailModel => ({
   })),
   characterType: faker.helpers.arrayElement(['TRUE', 'PIPI', 'TOBBY', 'BUDDY']),
 });
+
+export const createIdCardMock: IdCardCreateResponse = { id: 1 };

--- a/src/mocks/idCard/idCard.mockHandler.ts
+++ b/src/mocks/idCard/idCard.mockHandler.ts
@@ -3,12 +3,13 @@ import { rest } from 'msw';
 import { ROOT_API_URL } from '~/api/config/requestUrl';
 import { createIdCardMock, idCardDetailMock } from '~/mocks/idCard/idCard.mock';
 
+export const idCardCreateMockHandler = rest.post(`${ROOT_API_URL}/id-cards`, (req, res, ctx) =>
+  res(ctx.status(200), ctx.json(createIdCardMock)),
+);
+
 export const idCardMockHandler = [
   rest.get(`${ROOT_API_URL}/id-cards/:idCardId`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({ idCardDetailsDto: idCardDetailMock() }));
   }),
+  idCardCreateMockHandler,
 ];
-
-export const idCardCreateMockHandler = rest.post(`${ROOT_API_URL}/id-cards`, (req, res, ctx) =>
-  res(ctx.status(200), ctx.json(createIdCardMock)),
-);

--- a/src/mocks/idCard/idCard.mockHandler.ts
+++ b/src/mocks/idCard/idCard.mockHandler.ts
@@ -9,7 +9,6 @@ export const idCardMockHandler = [
   }),
 ];
 
-export const idCardCreateMockHandler = rest.post(
-  `${ROOT_API_URL}/id-cards/create`,
-  (req, res, ctx) => res(ctx.status(200), ctx.json(createIdCardMock)),
+export const idCardCreateMockHandler = rest.post(`${ROOT_API_URL}/id-cards`, (req, res, ctx) =>
+  res(ctx.status(200), ctx.json(createIdCardMock)),
 );

--- a/src/mocks/idCard/idCard.mockHandler.ts
+++ b/src/mocks/idCard/idCard.mockHandler.ts
@@ -1,9 +1,15 @@
 import { rest } from 'msw';
 
 import { ROOT_API_URL } from '~/api/config/requestUrl';
+import { createIdCardMock, idCardDetailMock } from '~/mocks/idCard/idCard.mock';
 
 export const idCardMockHandler = [
   rest.get(`${ROOT_API_URL}/id-cards/:idCardId`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({ idCardDetailsDto: idCardDetailMock() }));
   }),
 ];
+
+export const idCardCreateMockHandler = rest.post(
+  `${ROOT_API_URL}/id-cards/create`,
+  (req, res, ctx) => res(ctx.status(200), ctx.json(createIdCardMock)),
+);

--- a/src/mocks/idCard/idCard.mockHandler.ts
+++ b/src/mocks/idCard/idCard.mockHandler.ts
@@ -1,12 +1,9 @@
 import { rest } from 'msw';
 
 import { ROOT_API_URL } from '~/api/config/requestUrl';
-import { createIdCard } from '~/mocks/idCard/idCard.mock';
 
-const idCardMockHandler = [
+export const idCardMockHandler = [
   rest.get(`${ROOT_API_URL}/id-cards/:idCardId`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ idCardDetailsDto: createIdCard() }));
+    return res(ctx.status(200), ctx.json({ idCardDetailsDto: idCardDetailMock() }));
   }),
 ];
-
-export default idCardMockHandler;

--- a/src/modules/IdCardCreation/Form/IdCardCreationForm.tsx
+++ b/src/modules/IdCardCreation/Form/IdCardCreationForm.tsx
@@ -27,7 +27,7 @@ export const IdCardCreationForm = ({
   onSubmit,
 }: IdCardCreationFormProps) => {
   const {
-    formState: { errors, isDirty, isValid },
+    formState: { errors, isDirty, isValid, isSubmitting },
   } = useFormContext<IdCardCreationFormModel>();
 
   const getNavigationButton = () => {
@@ -52,7 +52,11 @@ export const IdCardCreationForm = ({
       case 'KEYWORD_CONTENT':
         disableStyle = (!isValid && disableButtonStyle) || '';
         return (
-          <button className={tw(disableStyle, 'submission')} disabled={!isValid} onClick={onSubmit}>
+          <button
+            className={tw(disableStyle, 'submission')}
+            disabled={!isValid || isSubmitting}
+            onClick={onSubmit}
+          >
             제출
           </button>
         );

--- a/src/modules/IdCardCreation/Form/IdCardCreationForm.tsx
+++ b/src/modules/IdCardCreation/Form/IdCardCreationForm.tsx
@@ -14,6 +14,7 @@ type IdCardCreationFormProps = {
   stepOrder: number;
   onNext: () => void;
   onPrev: () => void;
+  onSubmit: () => void;
 };
 
 const disableButtonStyle = 'text-grey-400';
@@ -23,17 +24,11 @@ export const IdCardCreationForm = ({
   stepOrder,
   onNext,
   onPrev,
+  onSubmit,
 }: IdCardCreationFormProps) => {
   const {
-    handleSubmit,
     formState: { errors, isDirty, isValid },
   } = useFormContext<IdCardCreationFormModel>();
-
-  const onSubmit = () => {
-    const api = () => 'api 실행';
-    handleSubmit(api);
-    onNext();
-  };
 
   const getNavigationButton = () => {
     let error;

--- a/src/modules/IdCardCreation/IdCardCreationSteps.stories.tsx
+++ b/src/modules/IdCardCreation/IdCardCreationSteps.stories.tsx
@@ -1,6 +1,7 @@
 import type { StoryObj } from '@storybook/react';
 
 import Button from '~/components/Button/Button';
+import { idCardCreateMockHandler } from '~/mocks/idCard/idCard.mockHandler';
 import { IdCard } from '~/modules/IdCard/IdCard.client';
 import { BoardingStep, LoadingStep } from '~/modules/IdCardCreation/Step';
 
@@ -14,6 +15,11 @@ export default {
 type Story = StoryObj<typeof IdCardCreationSteps>;
 
 export const Default: Story = {};
+Default.parameters = {
+  msw: {
+    handlers: [idCardCreateMockHandler],
+  },
+};
 
 export const Loading = {
   render: () => <LoadingStep planetName="Ding dong" />,

--- a/src/modules/IdCardCreation/IdCardCreationSteps.tsx
+++ b/src/modules/IdCardCreation/IdCardCreationSteps.tsx
@@ -19,7 +19,7 @@ const schema = yup.object({
   communityId: yup.number(),
   nickname: yup.string().required('이름을 입력해 주세요.'),
   aboutMe: yup.string(),
-  keywords: yup.array().default([]),
+  keywords: yup.array().min(1).default([]).required(),
 });
 
 export const IdCardCreationSteps = () => {
@@ -36,9 +36,15 @@ export const IdCardCreationSteps = () => {
   const onNext = () => setStepOrder(stepOrder + 1);
   const onPrev = () => setStepOrder(stepOrder - 1);
 
-  const { mutateAsync } = usePostIdCardCreate({ onSuccess: data => setUserId(data.id) });
+  const { mutateAsync } = usePostIdCardCreate({
+    onSuccess: data => {
+      setUserId(data.id);
+    },
+  });
   const onSubmit = () => {
-    methods.handleSubmit(async data => await mutateAsync(data));
+    methods.handleSubmit(async data => {
+      await mutateAsync(data);
+    })();
     onNext();
   };
 

--- a/src/modules/IdCardCreation/Step/CompleteStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/CompleteStep.client.tsx
@@ -4,22 +4,26 @@ import { useFormContext } from 'react-hook-form';
 
 import Button from '~/components/Button/Button';
 import { IdCard } from '~/modules/IdCard/IdCard.client';
-import { KeywordModel } from '~/types/idCard';
+import { IdCardCreationFormModel } from '~/types/idCard';
 
 const title = 'planet이름';
 
-export const CompleteStep = () => {
-  const { getValues } = useFormContext();
+type CompleteStepProps = {
+  userId: number;
+};
+
+export const CompleteStep = ({ userId }: CompleteStepProps) => {
+  const { getValues } = useFormContext<IdCardCreationFormModel>();
   const values = getValues();
   const { nickname, aboutMe, keywords } = values;
-  const keywordTitles = keywords.map((keyword: KeywordModel) => keyword.title);
+  const keywordTitles = keywords.map(keyword => keyword.title);
   return (
     // TODO: 지금은 커뮤니티 정보가 없는데 나중에 커뮤니티 타이틀 추가
     <div className="flex min-h-[calc(100vh-50px)] flex-col px-layout-sm ">
       <h2 className="text-h1 text-grey-900">{`짜잔!${title} \n주민증이 발급되었어요!`}</h2>
       <div className="mt-24pxr flex flex-1 flex-col">
         <IdCard
-          idCardId={values.id}
+          idCardId={userId}
           aboutMe={aboutMe}
           keywordTitles={keywordTitles}
           nickname={nickname}

--- a/src/modules/IdCardCreation/Step/KeywordContentStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/KeywordContentStep.client.tsx
@@ -2,13 +2,13 @@
 import { useFormContext } from 'react-hook-form';
 
 import { KeywordContentEditCard } from '~/modules/KeywordContentEditCard';
-import { FormKeywordModel } from '~/types/idCard';
+import { FormKeywordModel, IdCardCreationFormModel } from '~/types/idCard';
 
 const title = '나를 소개하는 키워드의\n 설명을 적어주세요!';
 
 export const KeywordContentStep = () => {
-  const { watch } = useFormContext();
-  const { keywords } = watch();
+  const { getValues } = useFormContext<IdCardCreationFormModel>();
+  const keywords = getValues('keywords');
 
   return (
     <div className="px-layout-sm">

--- a/src/modules/IdCardEditor/IdCardEditorSteps.stories.tsx
+++ b/src/modules/IdCardEditor/IdCardEditorSteps.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { createIdCard } from '~/mocks/idCard/idCard.mock';
+import { idCardDetailMock } from '~/mocks/idCard/idCard.mock';
 
 import { IdCardEditor } from './index';
 
@@ -14,7 +14,7 @@ export default meta;
 
 type Story = StoryObj<typeof IdCardEditor>;
 
-const MOCK_ID_CARD = createIdCard();
+const MOCK_ID_CARD = idCardDetailMock();
 
 const keywordsWithoutId = MOCK_ID_CARD.keywords.map(({ title, imageUrl, content }) => ({
   title,

--- a/src/types/idCard/request.type.ts
+++ b/src/types/idCard/request.type.ts
@@ -1,5 +1,6 @@
 import { IdCardCreationFormModel, IdCardEditorFormModel } from '~/types/idCard';
 
 export type CreateIdCardRequest = IdCardCreationFormModel;
+export type IdCardCreateRequest = IdCardCreationFormModel;
 
 export type EditIdCardRequest = IdCardEditorFormModel;

--- a/src/types/idCard/request.type.ts
+++ b/src/types/idCard/request.type.ts
@@ -1,6 +1,5 @@
 import { IdCardCreationFormModel, IdCardEditorFormModel } from '~/types/idCard';
 
-export type IdCardCreateRequest = IdCardCreationFormModel;
 export type CreateIdCardRequest = IdCardCreationFormModel;
 
 export type EditIdCardRequest = IdCardEditorFormModel;

--- a/src/types/idCard/request.type.ts
+++ b/src/types/idCard/request.type.ts
@@ -1,3 +1,3 @@
 import { IdCardCreationFormModel } from '~/types/idCard';
 
-export type CreateIdCardRequest = IdCardCreationFormModel;
+export type IdCardCreateRequest = IdCardCreationFormModel;

--- a/src/types/idCard/response.type.ts
+++ b/src/types/idCard/response.type.ts
@@ -7,3 +7,5 @@ export type CommentCountResponse = {
 export type IdCardDetailResponse = {
   idCardDetailsDto: IdCardDetailModel;
 };
+
+export type IdCardCreateResponse = { id: number };


### PR DESCRIPTION
### ⛳️ Task

- id card 생성 post api를 추가합니다.
- poast api에 대한 사용자 id 반환(response)에 따라 동작을 추가합니다.
- mocking 을 추가합니다.
- validation 누락된 부분과 handlesubmit 이 동작하도록 수정합니다.
- api가 전송될 때 버튼이 disable 되도록 만듭니다.

### note
mock handler 처리에 대해서 맞추는 논의가 필요한 것 같습니다. 수요일 회의 때 안건으로 올리겠습니다!

### ⚡️ Test
privateApi 가 현재 동작하지 않아 [코드](https://github.com/depromeet/Ding-dong-fe/blob/a1223b4974981670015bac6beb328dcd5e8a02db/src/api/domain/idCard.api.ts#L11)를 publicApi 로 바꾸어야 동작합니다.
[storybook](http://localhost:6006/?path=/story/modules-idcardsteps--default)에서 확인할 수 있습니다.

### 📎 Reference
[Figma](https://www.figma.com/file/TqXqE20VX7V1sw71TYj8qO/DD-_-WIRE-FRAME?type=design&node-id=475-6020&t=to63ZDadqhhJtwo0-4)
[Swagger](http://43.201.214.187/api/swagger-ui/index.html#/%EC%A3%BC%EB%AF%BC%EC%A6%9D/postIdCard)