### PR TITLE
Dep 116 Add image upload api

### DIFF
--- a/src/api/domain/image.api.ts
+++ b/src/api/domain/image.api.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationOptions, useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 import privateApi from '~/api/config/privateApi';

--- a/src/api/domain/image.api.ts
+++ b/src/api/domain/image.api.ts
@@ -1,0 +1,23 @@
+import { useMutation, UseMutationOptions, useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import privateApi from '~/api/config/privateApi';
+import { ImageFileRequest } from '~/types/image/request.type';
+import { IamgeUrlResponse } from '~/types/image/response.type';
+
+export const postImageUrl = (imageFile: ImageFileRequest) => {
+  const formData = new FormData();
+  formData.append('image', imageFile);
+
+  return privateApi.post<IamgeUrlResponse>('/images', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+};
+
+export const usePostImageUrl = (
+  options?: Omit<UseMutationOptions<IamgeUrlResponse, AxiosError, ImageFileRequest>, 'mutationFn'>,
+) =>
+  useMutation<IamgeUrlResponse, AxiosError, ImageFileRequest>({
+    mutationFn: postImageUrl,
+    ...options,
+  });

--- a/src/components/ProfileImageEdit/ProfileImageEdit.client.tsx
+++ b/src/components/ProfileImageEdit/ProfileImageEdit.client.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { faker } from '@faker-js/faker/locale/ko';
 import Image from 'next/image';
 import { ChangeEvent, ForwardedRef, forwardRef, InputHTMLAttributes, memo, useState } from 'react';
 import { FieldPath, FieldValues, UseFormSetValue } from 'react-hook-form';
 
+import { usePostImageUrl } from '~/api/domain/image.api';
 import { CameraIcon } from '~/components/Icon/CameraIcon';
 import { tw } from '~/utils/tailwind.util';
 
@@ -21,15 +21,17 @@ function ProfileImageEditComponent<T extends FieldValues>(
   ref: ForwardedRef<HTMLInputElement>,
 ) {
   const [profileImage, setProfileImage] = useState<string>(defaultProfileImage);
+  const { mutateAsync } = usePostImageUrl();
 
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const onChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const imageFileList = e.target.files;
     if (imageFileList && imageFileList.length > 0) {
-      //TODO: S3 로직 추가 예정
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const fakerImage = faker.image.avatar() as any;
-      setProfileImage(fakerImage);
-      setValue(fieldName, fakerImage);
+      const data = await mutateAsync(imageFileList[0]);
+      if (data) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        setValue(fieldName, data.imageUrl as any);
+        setProfileImage(data.imageUrl);
+      }
     }
   };
 

--- a/src/mocks/image/image.mock.ts
+++ b/src/mocks/image/image.mock.ts
@@ -1,0 +1,5 @@
+import { faker } from '@faker-js/faker/locale/ko';
+
+export const imageUrlMock = {
+  imageUrl: faker.image.avatar(),
+};

--- a/src/mocks/image/image.mockHandler.ts
+++ b/src/mocks/image/image.mockHandler.ts
@@ -1,0 +1,11 @@
+import { rest } from 'msw';
+
+import { ROOT_API_URL } from '~/api/config/requestUrl';
+
+import { imageUrlMock } from './image.mock';
+
+export const ImageUrlMockHandler = rest.post(`${ROOT_API_URL}/images`, (req, res, ctx) =>
+  res(ctx.status(200), ctx.json(imageUrlMock)),
+);
+
+export const imageMockHandler = [ImageUrlMockHandler];

--- a/src/modules/IdCardCreation/IdCardCreationSteps.stories.tsx
+++ b/src/modules/IdCardCreation/IdCardCreationSteps.stories.tsx
@@ -1,6 +1,7 @@
 import type { StoryObj } from '@storybook/react';
 
 import Button from '~/components/Button/Button';
+import { ImageUrlMockHandler } from '~/mocks/image/image.mockHandler';
 import { IdCard } from '~/modules/IdCard/IdCard.client';
 import { BoardingStep, LoadingStep } from '~/modules/IdCardCreation/Step';
 
@@ -14,7 +15,11 @@ export default {
 type Story = StoryObj<typeof IdCardCreationSteps>;
 
 export const Default: Story = {};
-Default.parameters = {};
+Default.parameters = {
+  msw: {
+    handlers: [ImageUrlMockHandler],
+  },
+};
 
 export const Loading = {
   render: () => <LoadingStep planetName="Ding dong" />,

--- a/src/modules/IdCardCreation/Step/KeywordContentImage.client.tsx
+++ b/src/modules/IdCardCreation/Step/KeywordContentImage.client.tsx
@@ -15,7 +15,6 @@ export const KeywordContentImage = ({ index }: KeywordContentImageProps) => {
   const imageUrl = keywords[index].imageUrl;
 
   const onCancelClick = useCallback(() => {
-    //TODO: S3 로직 추가 예정
     setValue(`keywords.${index}.imageUrl`, '');
   }, [index, setValue]);
 

--- a/src/modules/KeywordContentEditCard/KeywordContentEditCard.client.tsx
+++ b/src/modules/KeywordContentEditCard/KeywordContentEditCard.client.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { faker } from '@faker-js/faker/locale/ko';
 import { ChangeEvent, useCallback, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
+import { usePostImageUrl } from '~/api/domain/image.api';
 import { KeywordContentImage } from '~/modules/IdCardCreation/Step/KeywordContentImage.client';
 import { KeywordContentCard } from '~/modules/IdCardDetail';
 import { FormKeywordModel } from '~/types/idCard';
@@ -23,6 +23,7 @@ export const KeywordContentEditCard = ({
   const { register, setValue } = useFormContext();
   const [textFocus, setTextFocus] = useState<boolean>();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { mutateAsync } = usePostImageUrl();
 
   const onCardClick = useCallback(() => {
     if (textareaRef.current) textareaRef.current.focus();
@@ -36,15 +37,16 @@ export const KeywordContentEditCard = ({
   }, []);
 
   const onImageChange = useCallback(
-    (e: ChangeEvent<HTMLInputElement>) => {
+    async (e: ChangeEvent<HTMLInputElement>) => {
       const imageFileList = e.target.files;
       if (imageFileList && imageFileList.length > 0) {
-        //TODO: S3 로직 추가 예정
-        const fakerImage = faker.image.avatar();
-        setValue(`keywords.${index}.imageUrl`, fakerImage);
+        const data = await mutateAsync(imageFileList[0]);
+        if (data) {
+          setValue(`keywords.${index}.imageUrl`, data.imageUrl);
+        }
       }
     },
-    [index, setValue],
+    [index, mutateAsync, setValue],
   );
 
   return (

--- a/src/types/image/index.ts
+++ b/src/types/image/index.ts
@@ -1,0 +1,1 @@
+export * from './model.type';

--- a/src/types/image/model.type.ts
+++ b/src/types/image/model.type.ts
@@ -2,6 +2,5 @@ export type ImageUrlModel = {
   imageUrl: string;
 };
 
-export type ImageFileModel = {
-  image: File;
-};
+export type ImageFileModel = File;
+

--- a/src/types/image/model.type.ts
+++ b/src/types/image/model.type.ts
@@ -1,0 +1,7 @@
+export type ImageUrlModel = {
+  imageUrl: string;
+};
+
+export type ImageFileModel = {
+  image: File;
+};

--- a/src/types/image/request.type.ts
+++ b/src/types/image/request.type.ts
@@ -1,0 +1,3 @@
+import { ImageFileModel } from './model.type';
+
+export type ImageFileRequest = ImageFileModel;

--- a/src/types/image/response.type.ts
+++ b/src/types/image/response.type.ts
@@ -1,0 +1,3 @@
+import { ImageUrlModel } from './model.type';
+
+export type IamgeUrlResponse = ImageUrlModel;


### PR DESCRIPTION
### ⛳️ Task

- image api 에 사용되는 type을 추가합니다.
- image api를 추가합니다.
- image api를 사용하는 컴포넌트에 추가합니다.
- mocking을 추가합니다.

### ✍️ Note

- publicApi 일 때, local에서 mocking을 추가해 실행할 경우 interceptor 에서 오류가 나는 것 같습니다. storybook에서는 잘 작동합니다.
해당 부분 다음 PR에서 해결하겠습니다. (참고 :  [Salck](https://depromeet13th.slack.com/archives/C052G0MBG3V/p1687079470959039?thread_ts=1687077901.338489&cid=C052G0MBG3V))
<img width="491" alt="image" src="https://github.com/depromeet/Ding-dong-fe/assets/55529617/9c03c6c1-681f-48e8-adc5-80c32ae3ef5f">


### ⚡️ Test

privateApi 가 현재 동작하지 않아 [코드](https://github.com/depromeet/Ding-dong-fe/blob/874c45551285a051eccf9b98d438f6ccd8adf8aa/src/api/domain/image.api.ts#L12)를 publicApi 로 바꾸어야 동작합니다.
[storybook](http://localhost:6006/?path=/story/modules-idcardsteps--default)에서 profile image를 변경해 보세요.

### 📎 Reference
[Swagger](http://43.201.214.187/api/swagger-ui/index.html#/%EC%9D%B4%EB%AF%B8%EC%A7%80/uploadImage)