### PR TITLE
Add storybook cookie addon

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,6 +13,7 @@ const config: StorybookConfig = {
       },
     },
     '@storybook/addon-viewport',
+    'storybook-addon-cookie',
   ],
   framework: {
     name: '@storybook/nextjs',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,7 +6,7 @@ import { initialize, mswDecorator } from 'msw-storybook-addon';
 import type { Preview } from '@storybook/react';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import * as defaultHandlers from '../src/mocks/handlers';
+import { handlers } from '../src/mocks/handlers';
 import { AUTH_COOKIE_KEYS } from '../src/types/auth/response.type';
 
 // TODO: Provider폴더 구조 정해지면 수정해야합니다!
@@ -43,7 +43,7 @@ const preview: Preview = {
     },
     msw: {
       handlers: {
-        default: defaultHandlers,
+        default: handlers,
       },
     },
     webpackFinal: async config => {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -11,6 +11,8 @@ import { AUTH_COOKIE_KEYS } from '../src/types/auth/response.type';
 
 // TODO: Provider폴더 구조 정해지면 수정해야합니다!
 const queryClient = new QueryClient();
+const now = new Date();
+const expireDate = Number(now.setDate(now.getDate() + 1));
 
 // Initialize MSW
 initialize();
@@ -55,11 +57,10 @@ const preview: Preview = {
       return config;
     },
     cookie: {
-      //  TODO: 개발용 token으로 변경, env.dev 사용
       [AUTH_COOKIE_KEYS.accessToken]: '8888',
       [AUTH_COOKIE_KEYS.refreshToken]: '8888',
       [AUTH_COOKIE_KEYS.userId]: '8888',
-      [AUTH_COOKIE_KEYS.accessTokenExpireDate]: '8888',
+      [AUTH_COOKIE_KEYS.accessTokenExpireDate]: expireDate,
     },
   },
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,7 +6,7 @@ import { initialize, mswDecorator } from 'msw-storybook-addon';
 import type { Preview } from '@storybook/react';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import handlers from '../src/mocks/handlers';
+import * as defaultHandlers from '../src/mocks/handlers';
 import { AUTH_COOKIE_KEYS } from '../src/types/auth/response.type';
 
 // TODO: Provider폴더 구조 정해지면 수정해야합니다!
@@ -42,7 +42,9 @@ const preview: Preview = {
       appDirectory: true,
     },
     msw: {
-      handlers,
+      handlers: {
+        default: defaultHandlers,
+      },
     },
     webpackFinal: async config => {
       config.resolve.alias = {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,6 +7,7 @@ import type { Preview } from '@storybook/react';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import handlers from '../src/mocks/handlers';
+import { AUTH_COOKIE_KEYS } from '../src/types/auth/response.type';
 
 // TODO: Provider폴더 구조 정해지면 수정해야합니다!
 const queryClient = new QueryClient();
@@ -50,6 +51,13 @@ const preview: Preview = {
       };
 
       return config;
+    },
+    cookie: {
+      //  TODO: 개발용 token으로 변경, env.dev 사용
+      [AUTH_COOKIE_KEYS.accessToken]: '8888',
+      [AUTH_COOKIE_KEYS.refreshToken]: '8888',
+      [AUTH_COOKIE_KEYS.userId]: '8888',
+      [AUTH_COOKIE_KEYS.accessTokenExpireDate]: '8888',
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.3.0",
     "storybook": "^7.0.14",
+    "storybook-addon-cookie": "^3.0.1",
     "typescript": "5.0.4",
     "yup": "^1.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ devDependencies:
   storybook:
     specifier: ^7.0.14
     version: 7.0.14
+  storybook-addon-cookie:
+    specifier: ^3.0.1
+    version: 3.0.1(@storybook/blocks@7.0.14)(@storybook/components@7.0.20)(@storybook/manager-api@7.0.20)(@storybook/preview-api@7.0.20)(@storybook/types@7.0.20)(react-dom@18.2.0)(react@18.2.0)
   typescript:
     specifier: 5.0.4
     version: 5.0.4
@@ -11327,6 +11330,31 @@ packages:
 
   /store2@2.14.2:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
+    dev: true
+
+  /storybook-addon-cookie@3.0.1(@storybook/blocks@7.0.14)(@storybook/components@7.0.20)(@storybook/manager-api@7.0.20)(@storybook/preview-api@7.0.20)(@storybook/types@7.0.20)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-ne3jttK7rcJ2Lc5eZPi6h6/erKyIcfzuNPxLtvAssl+HRUtJ6OB4iEvYFFV9/nTxsuNlBkUILEkImqRFf/Bppg==}
+    peerDependencies:
+      '@storybook/blocks': ^7.0.0
+      '@storybook/components': ^7.0.0
+      '@storybook/manager-api': ^7.0.0
+      '@storybook/preview-api': ^7.0.0
+      '@storybook/types': ^7.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/blocks': 7.0.14(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/components': 7.0.20(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/manager-api': 7.0.20(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/preview-api': 7.0.20
+      '@storybook/types': 7.0.20
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: true
 
   /storybook@7.0.14:

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,5 +1,5 @@
 import { setupWorker } from 'msw';
 
-import handlers from './handlers';
+import { handlers } from './handlers';
 
 export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,11 +3,9 @@ import { communityMockHandler } from '~/mocks/community/community.mockHandler';
 import { idCardMockHandler } from '~/mocks/idCard/idCard.mockHandler';
 import { userMockHandler } from '~/mocks/user/user.mockHandler';
 
-const handlers = [
+export const handlers = [
   ...idCardMockHandler,
   ...communityMockHandler,
   ...commentMockHandler,
   ...userMockHandler,
 ];
-
-export default handlers;

--- a/src/mocks/image/image.mockHandler.ts
+++ b/src/mocks/image/image.mockHandler.ts
@@ -4,8 +4,8 @@ import { ROOT_API_URL } from '~/api/config/requestUrl';
 
 import { imageUrlMock } from './image.mock';
 
-export const ImageUrlMockHandler = rest.post(`${ROOT_API_URL}/images`, (req, res, ctx) =>
-  res(ctx.status(200), ctx.json(imageUrlMock)),
-);
-
-export const imageMockHandler = [ImageUrlMockHandler];
+export const imageMockHandler = [
+  rest.post(`${ROOT_API_URL}/images`, (req, res, ctx) =>
+    res(ctx.status(200), ctx.json(imageUrlMock)),
+  ),
+];

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,5 +1,5 @@
 import { setupServer } from 'msw/node';
 
-import handlers from './handlers';
+import { handlers } from './handlers';
 
 export const server = setupServer(...handlers);

--- a/src/modules/IdCardCreation/IdCardCreationSteps.stories.tsx
+++ b/src/modules/IdCardCreation/IdCardCreationSteps.stories.tsx
@@ -1,7 +1,6 @@
 import type { StoryObj } from '@storybook/react';
 
 import { Button } from '~/components/Button';
-import { ImageUrlMockHandler } from '~/mocks/image/image.mockHandler';
 import { IdCard } from '~/modules/IdCard/IdCard.client';
 import { BoardingStep, LoadingStep } from '~/modules/IdCardCreation/Step';
 
@@ -15,11 +14,7 @@ export default {
 type Story = StoryObj<typeof IdCardCreationSteps>;
 
 export const Default: Story = {};
-Default.parameters = {
-  msw: {
-    handlers: [ImageUrlMockHandler],
-  },
-};
+Default.parameters = {};
 
 export const Loading = {
   render: () => <LoadingStep planetName="Ding dong" />,


### PR DESCRIPTION
### ⛳️ Task

- storybook에서 privateApi를 사용할 수 있도록 cookie 를 설정합니다.
- preview에 설정된 handler가 overwrite 되지 않도록 key 값을 줍니다. ([Slack](https://depromeet13th.slack.com/archives/C052G0MBG3V/p1687079470959039?thread_ts=1687077901.338489&cid=C052G0MBG3V) 문제 해결)

### ✍️ Note

- cookie 값을 BE에게 받아서 env에 저장합니다. 선 PR 리뷰 먼저 진행 부탁드립니다!

### ⚡️ Test
[storybook](http://localhost:6006/?path=/story/modules-idcardsteps--default)에서 public api 사용 시 이미지 변경 및 제출 시 잘 작동하는 것을 확인할 수 있습니다.

### 📎 Reference
[Slack](https://depromeet13th.slack.com/archives/C052G0MBG3V/p1687079470959039?thread_ts=1687077901.338489&cid=C052G0MBG3V)