### PR TITLE
[Draft] Fix: community image

### DIFF
--- a/src/modules/CommunityProfile/CommunityLogoImage.tsx
+++ b/src/modules/CommunityProfile/CommunityLogoImage.tsx
@@ -5,7 +5,7 @@ type CommunityLogoImageProps = {
 };
 export const CommunityLogoImage = ({ logoImageUrl }: CommunityLogoImageProps) => {
   return (
-    <div className="h-60pxr w-60pxr flex-shrink-0 rounded-full">
+    <div className="h-60pxr w-60pxr flex-shrink-0 overflow-hidden rounded-full">
       <Image width={60} height={60} src={logoImageUrl} alt="planet logo image" />
     </div>
   );


### PR DESCRIPTION
### ⛳️ Task
1. 커뮤니티 로고 이미지가 원으로 보이지 않는 이슈가 있어서 수정했어요.
2. 커뮤니티 로고 이미지는 홈에서도 사용해서 컴포넌트를 재사용하도록 수정했어요.

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|   <img width="372" alt="스크린샷 2023-06-20 오전 11 13 26" src="https://github.com/depromeet/Ding-dong-fe/assets/62633444/756f31b6-97f2-423d-b03c-e0bfec664460">    |    <img width="372" alt="스크린샷 2023-06-20 오전 11 14 40" src="https://github.com/depromeet/Ding-dong-fe/assets/62633444/d95cf2f7-781c-49fa-98d6-c803551038b1">   |

### 📎 Reference
