### PR TITLE
Dep 119 confirm pop up

### DIFF
--- a/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 
 import BottomSheet from './BottomSheet';
 import { useBottomSheet } from './useBottomSheet';

--- a/src/components/BottomSheet/BottomSheetFooterButton.tsx
+++ b/src/components/BottomSheet/BottomSheetFooterButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Button, { ButtonProps } from '~/components/Button/Button';
+import { Button, ButtonProps } from '~/components/Button';
 
 export const BottomSheetFooterButton = ({
   size = 'large',

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import Button from './Button';
+import { Button } from './Button';
 
 const meta: Meta<typeof Button> = {
   title: 'components/Button',

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -25,7 +25,7 @@ const sizes: Record<ButtonSize, string> = {
   xLarge: 'py-17pxr text-[15px] rounded-xl',
 };
 
-const Button = ({
+export const Button = ({
   size,
   color,
   disabled = false,
@@ -53,5 +53,3 @@ const Button = ({
     </button>
   );
 };
-
-export default Button;

--- a/src/components/Button/TextButton.stories.tsx
+++ b/src/components/Button/TextButton.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import TextButton from './TextButton';
+import { TextButton } from './TextButton';
 
 const meta: Meta<typeof TextButton> = {
   title: 'components/TextButton',

--- a/src/components/Button/TextButton.tsx
+++ b/src/components/Button/TextButton.tsx
@@ -2,8 +2,6 @@ import { ButtonHTMLAttributes, PropsWithChildren } from 'react';
 
 export type TextButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & PropsWithChildren;
 
-const TextButton = ({ children, ...props }: TextButtonProps) => {
+export const TextButton = ({ children, ...props }: TextButtonProps) => {
   return <button {...props}>{children}</button>;
 };
-
-export default TextButton;

--- a/src/components/ConfirmPopup/ConfirmDeleteKeyword/ConfirmDeleteKeyword.client.tsx
+++ b/src/components/ConfirmPopup/ConfirmDeleteKeyword/ConfirmDeleteKeyword.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Button } from '~/components/Button';
-import TextButton from '~/components/Button/TextButton';
+import { TextButton } from '~/components/Button';
 import { ConfirmType } from '~/components/ConfirmPopup/useConfirmPopup';
 import Popup from '~/components/Popup/Popup';
 

--- a/src/components/ConfirmPopup/ConfirmDeleteKeyword/ConfirmDeleteKeyword.client.tsx
+++ b/src/components/ConfirmPopup/ConfirmDeleteKeyword/ConfirmDeleteKeyword.client.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { Button } from '~/components/Button';
+import TextButton from '~/components/Button/TextButton';
+import { ConfirmType } from '~/components/ConfirmPopup/useConfirmPopup';
+import Popup from '~/components/Popup/Popup';
+
+const TITLE = '키워드를 삭제하시겠어요?';
+const DESC = '키워드 세부 내용까지 없어져요';
+
+type ConfirmDeleteKeywordProps = {
+  confirm: (type: ConfirmType) => void;
+};
+
+export const ConfirmDeleteKeyword = ({ confirm }: ConfirmDeleteKeywordProps) => {
+  const buttons = (
+    <div className="flex w-full flex-col">
+      <Button onClick={() => confirm('CANCEL')} type="button" size="medium" color="primary">
+        취소
+      </Button>
+      <TextButton
+        onClick={() => confirm('OK')}
+        type="button"
+        className="rounded-xl pt-13pxr text-b3 text-grey-900"
+      >
+        삭제하기
+      </TextButton>
+    </div>
+  );
+
+  return <Popup title={TITLE} description={DESC} buttons={buttons} />;
+};

--- a/src/components/ConfirmPopup/ConfirmDeleteKeyword/ConfirmDeleteKeyword.stories.tsx
+++ b/src/components/ConfirmPopup/ConfirmDeleteKeyword/ConfirmDeleteKeyword.stories.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { Button } from '~/components/Button';
+import { useConfirmPopup } from '~/components/ConfirmPopup/useConfirmPopup';
+
+import { ConfirmDeleteKeyword } from './index';
+
+const meta: Meta<typeof ConfirmDeleteKeyword> = {
+  title: 'components/ConfirmDeleteKeyword',
+  component: ConfirmDeleteKeyword,
+  args: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ConfirmDeleteKeyword>;
+
+export const Primary: Story = {
+  render: () => {
+    const { isOpen, openPopup, closePopup, confirm } = useConfirmPopup();
+    const [confirmResult, setConfirmResult] = useState('Init');
+
+    const onClickConfirm = async () => {
+      const isOk = await openPopup();
+      setConfirmResult(() => (isOk ? 'Ok' : 'Cancel'));
+      closePopup();
+    };
+
+    return (
+      <div className="flex w-full flex-col items-center justify-center gap-20pxr">
+        <Button onClick={onClickConfirm} type="button" size="medium" color="primary">
+          Confirm팝업 실행하기
+        </Button>
+        <h1 className="text-h1">{confirmResult}</h1>
+        {isOpen && <ConfirmDeleteKeyword confirm={confirm} />}
+      </div>
+    );
+  },
+};

--- a/src/components/ConfirmPopup/ConfirmDeleteKeyword/index.ts
+++ b/src/components/ConfirmPopup/ConfirmDeleteKeyword/index.ts
@@ -1,0 +1,1 @@
+export * from './ConfirmDeleteKeyword.client';

--- a/src/components/ConfirmPopup/ConfirmUnSave/ConfirmUnSave.client.tsx
+++ b/src/components/ConfirmPopup/ConfirmUnSave/ConfirmUnSave.client.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { Button } from '~/components/Button';
+import TextButton from '~/components/Button/TextButton';
+import { ConfirmType } from '~/components/ConfirmPopup/useConfirmPopup';
+import Popup from '~/components/Popup/Popup';
+
+const TITLE = '저장되지 않은 변경사항이 있어요';
+const DESC = '변경 사항을 취소할까요?';
+
+type ConfirmUnSaveProps = {
+  confirm: (type: ConfirmType) => void;
+};
+
+export const ConfirmUnSave = ({ confirm }: ConfirmUnSaveProps) => {
+  const buttons = (
+    <div className="flex w-full flex-col">
+      <Button onClick={() => confirm('CANCEL')} type="button" size="medium" color="primary">
+        아니요
+      </Button>
+      <TextButton
+        onClick={() => confirm('OK')}
+        type="button"
+        className="rounded-xl pt-13pxr text-b3 text-grey-900"
+      >
+        네, 저장하지 않을래요
+      </TextButton>
+    </div>
+  );
+
+  return <Popup title={TITLE} description={DESC} buttons={buttons} />;
+};

--- a/src/components/ConfirmPopup/ConfirmUnSave/ConfirmUnSave.client.tsx
+++ b/src/components/ConfirmPopup/ConfirmUnSave/ConfirmUnSave.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Button } from '~/components/Button';
-import TextButton from '~/components/Button/TextButton';
+import { TextButton } from '~/components/Button';
 import { ConfirmType } from '~/components/ConfirmPopup/useConfirmPopup';
 import Popup from '~/components/Popup/Popup';
 

--- a/src/components/ConfirmPopup/ConfirmUnSave/ConfirmUnSave.stories.tsx
+++ b/src/components/ConfirmPopup/ConfirmUnSave/ConfirmUnSave.stories.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+
+import { Button } from '~/components/Button';
+import { useConfirmPopup } from '~/components/ConfirmPopup';
+
+import { ConfirmUnSave } from './index';
+
+const meta: Meta<typeof ConfirmUnSave> = {
+  title: 'components/ConfirmUnSave',
+  component: ConfirmUnSave,
+  args: {},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ConfirmUnSave>;
+
+export const Primary: Story = {
+  render: () => {
+    const { isOpen, openPopup, closePopup, confirm } = useConfirmPopup();
+    const [confirmResult, setConfirmResult] = useState('Init');
+
+    const onClickConfirm = async () => {
+      const isOk = await openPopup();
+      setConfirmResult(() => (isOk ? 'Ok' : 'Cancel'));
+      closePopup();
+    };
+
+    return (
+      <div className="flex w-full flex-col items-center justify-center gap-20pxr">
+        <Button onClick={onClickConfirm} type="button" size="medium" color="primary">
+          Confirm팝업 실행하기
+        </Button>
+        <h1 className="text-h1">{confirmResult}</h1>
+        {isOpen && <ConfirmUnSave confirm={confirm} />}
+      </div>
+    );
+  },
+};

--- a/src/components/ConfirmPopup/ConfirmUnSave/index.ts
+++ b/src/components/ConfirmPopup/ConfirmUnSave/index.ts
@@ -1,0 +1,1 @@
+export * from './ConfirmUnSave.client';

--- a/src/components/ConfirmPopup/index.ts
+++ b/src/components/ConfirmPopup/index.ts
@@ -1,0 +1,3 @@
+export * from './ConfirmDeleteKeyword';
+export * from './ConfirmUnSave';
+export * from './useConfirmPopup';

--- a/src/components/ConfirmPopup/useConfirmPopup.ts
+++ b/src/components/ConfirmPopup/useConfirmPopup.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+/**
+ * 단순 실행만 할 경우 "OPEN"
+ */
+export type ConfirmType = 'OK' | 'CANCEL' | 'OPEN';
+
+export const useConfirmPopup = (initialState = false) => {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const [resolveFunc, setResolveFunc] = useState<((result: boolean) => void) | null>(null);
+
+  const openPopup = () => {
+    setIsOpen(true);
+
+    return new Promise(resolve => {
+      setResolveFunc(() => resolve);
+    });
+  };
+
+  const closePopup = () => {
+    setIsOpen(false);
+  };
+
+  const confirm = (type: ConfirmType = 'OPEN') => {
+    const isOk = type === 'OK';
+    if (resolveFunc) {
+      resolveFunc(isOk);
+      setResolveFunc(null);
+    }
+  };
+
+  return {
+    isOpen,
+    openPopup,
+    closePopup,
+    confirm,
+  };
+};

--- a/src/components/Popup/Popup.stories.tsx
+++ b/src/components/Popup/Popup.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 
 import Popup from './Popup';
 

--- a/src/components/Popup/Popup.tsx
+++ b/src/components/Popup/Popup.tsx
@@ -4,7 +4,7 @@ import { ReactNode } from 'react';
 
 import { AnimatedPortal } from '~/components/Portal';
 
-type PopupProps = {
+export type PopupProps = {
   title?: string;
   description?: string;
   buttons?: ReactNode;
@@ -16,9 +16,9 @@ const Popup = ({ title, description, buttons }: PopupProps) => {
       motionProps={{ initial: { opacity: 0 }, animate: { opacity: 1 }, exit: { opacity: 0 } }}
     >
       <div className="fixed left-0 top-0 h-full w-full bg-black/50">
-        <div className="fixed left-2/4 top-2/4 w-72 -translate-x-2/4 -translate-y-2/4 rounded-xl bg-white p-6 text-center">
-          {title && <p className="text-base font-bold">{title}</p>}
-          {description && <p className="mb-5 mt-3 text-base font-normal">{description}</p>}
+        <div className="fixed left-2/4 top-2/4 w-72 -translate-x-2/4 -translate-y-2/4 rounded-xl bg-white p-22pxr text-center">
+          {title && <p className="text-h5 text-black ">{title}</p>}
+          {description && <p className="mb-5 mt-3 text-b1 font-normal text-black">{description}</p>}
           {buttons && <div className="flex gap-2">{buttons}</div>}
         </div>
       </div>

--- a/src/modules/CommunityAdmin/CommunityAdmin.tsx
+++ b/src/modules/CommunityAdmin/CommunityAdmin.tsx
@@ -1,4 +1,4 @@
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 import { KakaoIcon } from '~/components/Icon/KakaoIcon';
 import { TopNavigation } from '~/components/TopNavigation';
 import { CommunityBgImage, CommunityProfile } from '~/modules/CommunityProfile';

--- a/src/modules/CommunityAdmin/CommunityAdminEditForm.client.tsx
+++ b/src/modules/CommunityAdmin/CommunityAdminEditForm.client.tsx
@@ -1,7 +1,7 @@
 import { faker } from '@faker-js/faker';
 import { useFormContext } from 'react-hook-form';
 
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 import { ProfileImageEdit } from '~/components/ProfileImageEdit';
 import { TextArea, useTextArea } from '~/components/TextArea';
 import { TextInput, useTextInput } from '~/components/TextInput';

--- a/src/modules/CommunityProfile/CommunityBgImage.client.tsx
+++ b/src/modules/CommunityProfile/CommunityBgImage.client.tsx
@@ -4,7 +4,7 @@ import { faker } from '@faker-js/faker';
 import Image from 'next/image';
 import { ChangeEvent, useState } from 'react';
 
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 
 type CommunityBgImageProps = {
   coverImageUrl: string;

--- a/src/modules/IdCardCreation/IdCardCreationSteps.stories.tsx
+++ b/src/modules/IdCardCreation/IdCardCreationSteps.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryObj } from '@storybook/react';
 
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 import { ImageUrlMockHandler } from '~/mocks/image/image.mockHandler';
 import { IdCard } from '~/modules/IdCard/IdCard.client';
 import { BoardingStep, LoadingStep } from '~/modules/IdCardCreation/Step';

--- a/src/modules/IdCardCreation/Step/BoardingStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/BoardingStep.client.tsx
@@ -4,8 +4,7 @@ import Image from 'next/image';
 import { ReactNode, useState } from 'react';
 
 import BottomSheet, { useBottomSheet } from '~/components/BottomSheet';
-import { Button } from '~/components/Button';
-import TextButton from '~/components/Button/TextButton';
+import { Button, TextButton } from '~/components/Button';
 import { QuestionCircleIcon } from '~/components/Icon';
 import { Swiper, SwiperSlide } from '~/components/Swiper';
 

--- a/src/modules/IdCardCreation/Step/BoardingStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/BoardingStep.client.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { ReactNode, useState } from 'react';
 
 import BottomSheet, { useBottomSheet } from '~/components/BottomSheet';
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 import TextButton from '~/components/Button/TextButton';
 import { QuestionCircleIcon } from '~/components/Icon';
 import { Swiper, SwiperSlide } from '~/components/Swiper';

--- a/src/modules/IdCardCreation/Step/CompleteStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/CompleteStep.client.tsx
@@ -2,7 +2,7 @@
 
 import { useFormContext } from 'react-hook-form';
 
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 import { IdCard } from '~/modules/IdCard/IdCard.client';
 import { IdCardCreationFormModel } from '~/types/idCard';
 

--- a/src/modules/IdCardEditButton/IdCardEditButton.client.tsx
+++ b/src/modules/IdCardEditButton/IdCardEditButton.client.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { usePathname, useRouter } from 'next/navigation';
 
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 
 export const IdCardEditButton = () => {
   const pathname = usePathname();

--- a/src/modules/KeywordContentEditCard/KeywordContentEditCard.client.tsx
+++ b/src/modules/KeywordContentEditCard/KeywordContentEditCard.client.tsx
@@ -4,6 +4,7 @@ import { ChangeEvent, useCallback, useRef, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { usePostImageUrl } from '~/api/domain/image.api';
+import { ConfirmDeleteKeyword, useConfirmPopup } from '~/components/ConfirmPopup';
 import { CancelIcon } from '~/components/Icon';
 import { KeywordContentImage } from '~/modules/IdCardCreation/Step/KeywordContentImage.client';
 import { KeywordContentCard } from '~/modules/IdCardDetail';
@@ -26,6 +27,12 @@ export const KeywordContentEditCard = ({
   const [textFocus, setTextFocus] = useState<boolean>();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { mutateAsync } = usePostImageUrl();
+  const {
+    isOpen: isConfirmDeleteOpen,
+    openPopup: openConfirmDeletePopup,
+    closePopup: closeConfirmDeletePopup,
+    confirm: confirmDelete,
+  } = useConfirmPopup();
 
   const onCardClick = () => {
     if (textareaRef.current) textareaRef.current.focus();
@@ -36,9 +43,9 @@ export const KeywordContentEditCard = ({
     setValue('keywords', filteredKeywordList);
   };
 
-  const onDeleteKeywordContent = () => {
-    // TODO: pop up UI 수정하기
-    const isOk = window.confirm('키워드를 삭제하시겠어요?');
+  const onDeleteKeywordContent = async () => {
+    const isOk = await openConfirmDeletePopup();
+    closeConfirmDeletePopup();
     if (isOk) {
       deleteKeyword(keyword.title, keywords);
     }
@@ -107,6 +114,7 @@ export const KeywordContentEditCard = ({
           className="hidden"
         />
       </div>
+      {isConfirmDeleteOpen && <ConfirmDeleteKeyword confirm={confirmDelete} />}
     </div>
   );
 };

--- a/src/modules/PlanetEnterButton/PlanetEnterButton.client.tsx
+++ b/src/modules/PlanetEnterButton/PlanetEnterButton.client.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Button } from '~/components/Button';
-import TextButton from '~/components/Button/TextButton';
+import { Button, TextButton } from '~/components/Button';
 
 export const PlanetEnterButton = () => {
   return (

--- a/src/modules/PlanetEnterButton/PlanetEnterButton.client.tsx
+++ b/src/modules/PlanetEnterButton/PlanetEnterButton.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Button from '~/components/Button/Button';
+import { Button } from '~/components/Button';
 import TextButton from '~/components/Button/TextButton';
 
 export const PlanetEnterButton = () => {


### PR DESCRIPTION
### ⛳️ Task

1. 취소 confirm popup 구현
2. 삭제 confirm popup 구현 
3. Button, TextButton (export default -> named export)

### ✍️ Note

키워드 삭제 및 저장하지 않고 페이지를 벗어났을 때 활용할 수 있는 Confirm Popup 컴포넌트를 개발했어요. `주민증 수정`, `키워드 편집 컴포넌트`에 적용했어요.

자세한 동작은 스토리북으로 참고해주세요! 

 🚨팝업 및 모달과 관련해서 현재 문제점이 있어요

- 지금은 popup사용하려면 컴포넌트에서 3부분을 건들어야 해요. tsx부분 컴포넌트를 선언하고, 핸들러에 추가하고, usePop으로 열고 닫는 로직을 추가해야해요
```
usePop선언
// 컴포넌트 로직
이벤트 핸들러 선언
// 컴포넌트 로직
jsx에 popup컴포넌트 삽입
```
- add Pop()과 같은 표준화된 로직만 호출하면 jsx부분에 따로 선언할 필요 없이 pop portal에 추가되는 로직을 짜면 어떨까 싶네요

### ⚡️ Test

### 📸 Screenshot

- [Confirm Delete Keyword](https://6478b0e59073c507c3cc3944-dnjvlswsou.chromatic.com/?path=/story/components-confirmdeletekeyword--primary)
- [Confirm Delete Unsave](https://6478b0e59073c507c3cc3944-dnjvlswsou.chromatic.com/?path=/story/components-confirmunsave--primary)
- [주민증 수정에 적용](https://6478b0e59073c507c3cc3944-dnjvlswsou.chromatic.com/?path=/story/modules-idcardeditor--primary)

### 📎 Reference

[팝업 관리 & Cofirm 팝업 만들기](https://www.notion.so/depromeet/Cofirm-181076497d184903be1ac1b3c22d0323?pvs=4)
