### PR TITLE
Refactor: 답글 숨기기, 펼치기 버튼 분리

### DIFF
--- a/src/modules/CommentList/Comment/Comment.client.tsx
+++ b/src/modules/CommentList/Comment/Comment.client.tsx
@@ -7,6 +7,7 @@ import {
   Header,
   LikeCount,
   LikeIcon,
+  ReplyHideButton,
   ReplyShowButton,
   ReplySubmitButton,
   UserProfile,
@@ -54,11 +55,16 @@ export const Comment = ({
         </div>
         <ReplyShowButton
           isShowReplyList={isShowReplyList}
-          onClickHideReplyList={onClickHideReplyList}
           onClickShowReplyList={onClickShowReplyList}
           commentReplyInfos={commentReplyInfos}
         />
         <CommentReplyList isShowReplyList={isShowReplyList} commentReplyInfos={commentReplyInfos} />
+        <div className="mt-24pxr">
+          <ReplyHideButton
+            isShowReplyList={isShowReplyList}
+            onClickHideReplyList={onClickHideReplyList}
+          />
+        </div>
       </div>
     </li>
   );

--- a/src/modules/CommentList/CommentCommon/ReplyHideButton.client.tsx
+++ b/src/modules/CommentList/CommentCommon/ReplyHideButton.client.tsx
@@ -1,0 +1,22 @@
+import { DashIcon } from '~/components/Icon';
+
+type ReplyHideButtonProps = {
+  isShowReplyList: boolean;
+  onClickHideReplyList: VoidFunction;
+};
+
+export const ReplyHideButton = ({
+  isShowReplyList,
+  onClickHideReplyList,
+}: ReplyHideButtonProps) => {
+  return (
+    <>
+      {isShowReplyList && (
+        <button type="button" onClick={onClickHideReplyList} className="mt-24pxr flex gap-8pxr">
+          <DashIcon className="fill-grey-500" />
+          <span className="text-detail font-semibold text-grey-500">답글 숨기기</span>
+        </button>
+      )}
+    </>
+  );
+};

--- a/src/modules/CommentList/CommentCommon/ReplyShowButton.client.tsx
+++ b/src/modules/CommentList/CommentCommon/ReplyShowButton.client.tsx
@@ -3,24 +3,17 @@ import { CommentModel } from '~/types/comment';
 
 type ReplyShowButtonProps = Pick<CommentModel, 'commentReplyInfos'> & {
   isShowReplyList: boolean;
-  onClickHideReplyList: VoidFunction;
   onClickShowReplyList: VoidFunction;
 };
 
 export const ReplyShowButton = ({
   isShowReplyList,
-  onClickHideReplyList,
   onClickShowReplyList,
   commentReplyInfos,
 }: ReplyShowButtonProps) => {
   return (
     <>
-      {isShowReplyList ? (
-        <button type="button" onClick={onClickHideReplyList} className="mt-24pxr flex gap-8pxr">
-          <DashIcon className="fill-grey-500" />
-          <span className="text-detail font-semibold text-grey-500">답글 숨기기</span>
-        </button>
-      ) : (
+      {!isShowReplyList && (
         <button type="button" onClick={onClickShowReplyList} className="mt-24pxr flex gap-8pxr">
           <DashIcon className="fill-grey-500" />
           <span className="text-detail font-semibold text-grey-500">

--- a/src/modules/CommentList/CommentCommon/index.ts
+++ b/src/modules/CommentList/CommentCommon/index.ts
@@ -2,6 +2,7 @@ export * from './Content.client';
 export * from './Header.client';
 export * from './LikeCount.client';
 export * from './LikeIcon.client';
+export * from './ReplyHideButton.client';
 export * from './ReplyShowButton.client';
 export * from './ReplySubmitButton.client';
 export * from './UserProfile.client';


### PR DESCRIPTION
### ⛳️ Task

답글 보여주기 버튼 기능을 분리했어요. 

-> 답글 숨기기 버튼과 답글 더보기 버튼 

이유: 답글 숨기기버튼은 답글 리스트 맨 하단에 있고, 답글 더보기 버튼은 답글 리스트 맨 상단에 있어서 분리해야해요. 

답글 숨기기하면 알아서 스크롤이 위로 올라와요(의도하지 않았는데 되네요 ㅎㅎ)

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

[답글 펼치기 스토리](https://6478b0e59073c507c3cc3944-jittrforne.chromatic.com/?path=/story/modules-comment--primary)

### 📎 Reference

댓글 컴포넌트 구조 관련된 내용은 https://github.com/depromeet/Ding-dong-fe/pull/96 를 참고해주세요
