### PR TITLE
feat: getUserIdClient 서버사이드 가드 추가

### DIFF
--- a/src/utils/auth/getUserId.client.ts
+++ b/src/utils/auth/getUserId.client.ts
@@ -2,7 +2,12 @@ import { UserIdNotFoundError } from './error';
 import { getAuthTokensByCookie } from './tokenHandlers';
 
 export const getUserIdClient = (): number => {
-  const { userId } = getAuthTokensByCookie(document.cookie);
-  if (userId !== undefined) return userId;
-  throw new UserIdNotFoundError();
+  try {
+    if (typeof document === 'undefined') throw new UserIdNotFoundError();
+    const { userId } = getAuthTokensByCookie(document.cookie);
+    if (userId !== undefined) return userId;
+    throw new UserIdNotFoundError();
+  } catch (e) {
+    return -1;
+  }
 };

--- a/src/utils/auth/getUserId.server.ts
+++ b/src/utils/auth/getUserId.server.ts
@@ -8,11 +8,11 @@ export const getUserIdServer = (): number => {
   try {
     const cookieStore = cookies();
     const userId = cookieStore.get(AUTH_COOKIE_KEYS.userId)?.value;
-    if (userId === undefined) throw new Error();
+    if (userId === undefined) throw new UserIdNotFoundError();
     const userIdNumber = Number(userId);
-    if (isNaN(userIdNumber)) throw new Error();
+    if (isNaN(userIdNumber)) throw new UserIdNotFoundError();
     return userIdNumber;
   } catch (e) {
-    throw new UserIdNotFoundError();
+    return -1;
   }
 };


### PR DESCRIPTION
### ⛳️ Task
getUserIdClient 관련 빌드 에러를 수정했습니다.
- `Collecting page data ...ReferenceError: document is not defined`에러가 발생하며 빌드가 실패하였고 이를 해결하기 위해 document가 정의되지 않은 경우 처리를 추가했습니다.
- next에서 페이지가 클라이언트에 mount되기 전까지 기다리도록 window !== undefined등의 로직을 많이 사용하는것 같습니다. 
- 서버사이드에서 에러를 던질시 현재 캐치하는 부분이 없어 에러시 -1을 반환하도록 임시로 처리했습니다. 에러를 던질시 빌드에러가 발생합니다.
### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
