### PR TITLE
답글 없을 때 [답글 보여주기] UI  수정

### DIFF
--- a/src/modules/CommentList/CommentCommon/Content.client.tsx
+++ b/src/modules/CommentList/CommentCommon/Content.client.tsx
@@ -16,7 +16,7 @@ export const Content = ({ content }: ContentProps) => {
   const [isShowDetail, setIsShowDetail] = useState(true); // Content의 line-height에 상관없이 우선 무조건 보여주기 (useEffect에서 MAX_LINE 넘으면 생략)
   const [isShowButton, setIsShowButton] = useState(false);
   const buttonLabel = isShowDetail ? '접기' : '자세히보기';
-  const lineClampClass = isShowDetail ? '' : `line-clamp-${MAX_LINE}`;
+  const lineClampClass = isShowDetail ? '' : `line-clamp-5`; // FIXME: MAX_LINE 변수를 쓰고 싶은데 tailwind가 잘 안 먹혀요ㅠㅠ
 
   const shouldHideOverflowContent = () => {
     const contentElement = paragraphRef.current;

--- a/src/modules/CommentList/CommentCommon/Content.client.tsx
+++ b/src/modules/CommentList/CommentCommon/Content.client.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { CommentModel } from '~/types/comment';
 import { tw } from '~/utils/tailwind.util';
@@ -7,13 +7,14 @@ import { tw } from '~/utils/tailwind.util';
 type ContentProps = Pick<CommentModel, 'content'>;
 
 const MAX_LINE = 5;
-
-const isOverMaxHeight = (elementOffsetHeight: number, maxHeight: number) =>
-  elementOffsetHeight > maxHeight;
+/**
+ * content의 줄 수가 최대 줄 수를 초과하는지 확인
+ */
+const isOverflowing = (actualLines: number, maxLine: number) => actualLines > maxLine;
 
 export const Content = ({ content }: ContentProps) => {
   const paragraphRef = useRef<HTMLParagraphElement>(null);
-  const [isShowDetail, setIsShowDetail] = useState(true); // Content의 line-height에 상관없이 우선 무조건 보여주기 (useEffect에서 MAX_LINE 넘으면 생략)
+  const [isShowDetail, setIsShowDetail] = useState(false); // Content의 line-height에 상관없이 우선 무조건 안 보여주기 (useLayoutEffect에서 isOverflowing 실행 )
   const [isShowButton, setIsShowButton] = useState(false);
   const buttonLabel = isShowDetail ? '접기' : '자세히보기';
   const lineClampClass = isShowDetail ? '' : `line-clamp-5`; // FIXME: MAX_LINE 변수를 쓰고 싶은데 tailwind가 잘 안 먹혀요ㅠㅠ
@@ -28,17 +29,18 @@ export const Content = ({ content }: ContentProps) => {
         window.getComputedStyle(contentElement).getPropertyValue('line-height')!;
 
       const lineHeight = lineHeightString ? parseInt(lineHeightString, 10) : 0;
-      const maxHeight = lineHeight * MAX_LINE;
+      const actualLines = contentElement.scrollHeight / lineHeight;
 
-      if (isOverMaxHeight(contentElement.offsetHeight, maxHeight)) {
+      // content의 줄 수가 최대 줄 수를 초과하는지 확인
+      if (isOverflowing(actualLines, MAX_LINE)) {
         setIsShowButton(true);
         setIsShowDetail(false);
       }
     }
   };
 
-  // line-clamp 속성만으로 MAX_LINE 이상이면 생략되게 가능하지만, content의 길이에 따라 다르게 설정해야하기 때문에 useEffect가 필요해요
-  useEffect(() => {
+  // line-clamp 속성만으로 MAX_LINE 이상이면 생략되게 가능하지만, content의 길이에 따라 다르게 설정해야하기 때문에 useLayoutEffect가 필요해요
+  useLayoutEffect(() => {
     shouldHideOverflowContent();
   }, []);
 

--- a/src/modules/CommentList/CommentCommon/ReplyShowButton.client.tsx
+++ b/src/modules/CommentList/CommentCommon/ReplyShowButton.client.tsx
@@ -11,9 +11,13 @@ export const ReplyShowButton = ({
   onClickShowReplyList,
   commentReplyInfos,
 }: ReplyShowButtonProps) => {
+  const isReplyListEmpty = commentReplyInfos.length === 0;
+
+  const isShowButton = !isShowReplyList && !isReplyListEmpty;
+
   return (
     <>
-      {!isShowReplyList && (
+      {isShowButton && (
         <button type="button" onClick={onClickShowReplyList} className="mt-24pxr flex gap-8pxr">
           <DashIcon className="fill-grey-500" />
           <span className="text-detail font-semibold text-grey-500">


### PR DESCRIPTION
### ⛳️ Task

- 답글이 0개일 때는 답글 펼치기 버튼 안보이게 하기
- 댓글 상세보기가 제대로 동작하지 않은 버그 수정(tw js 변수가 적용되지 않은 문제...)
- 댓글 상세보기 초기 레더링 시 깜빡거리는 불편함 수정 
  - useEffect -> useLayoutEffect
  - 초기 값 변경

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
