### PR TITLE
서버 기본 response 타입 

### DIFF
--- a/src/api/config/api.types.ts
+++ b/src/api/config/api.types.ts
@@ -33,3 +33,9 @@ export type FetchResponseType<T> = {
   status: number;
   data?: T;
 };
+
+export type DefaultServerResponseType = {
+  data: any;
+  statusCode: number;
+  success: boolean;
+};

--- a/src/api/config/api.types.ts
+++ b/src/api/config/api.types.ts
@@ -34,8 +34,8 @@ export type FetchResponseType<T> = {
   data?: T;
 };
 
-export type DefaultServerResponseType = {
-  data: any;
+export type DefaultServerResponseType<T> = {
+  data: T;
   statusCode: number;
   success: boolean;
 };

--- a/src/api/config/api.types.ts
+++ b/src/api/config/api.types.ts
@@ -34,8 +34,8 @@ export type FetchResponseType<T> = {
   data?: T;
 };
 
-export type DefaultServerResponseType<T> = {
-  data: T;
+export type DefaultServerResponseType<DataType> = {
+  data: DataType;
   statusCode: number;
   success: boolean;
 };

--- a/src/api/config/interceptor.ts
+++ b/src/api/config/interceptor.ts
@@ -1,6 +1,6 @@
 import { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
-import { ErrorType } from '~/api/config/api.types';
+import { DefaultServerResponseType, ErrorType } from '~/api/config/api.types';
 import { getAccessToken, getAuthTokensByCookie } from '~/utils/auth/tokenHandlers';
 
 import { ApiError } from './customError';
@@ -26,9 +26,10 @@ export const onRequestError = (error: AxiosError) => {
 };
 
 export const onResponse = (response: AxiosResponse) => {
-  const data = response.data;
-  const { headers, status } = response;
-  return { ...data, headers, status };
+  const defaultServerScheme: DefaultServerResponseType = response.data;
+  const { data, statusCode, success } = defaultServerScheme;
+  const { headers } = response;
+  return { ...data, headers, statusCode, success };
 };
 
 export const onResponseError = (error: AxiosError<ErrorType, InternalAxiosRequestConfig>) => {

--- a/src/api/config/interceptor.ts
+++ b/src/api/config/interceptor.ts
@@ -25,8 +25,8 @@ export const onRequestError = (error: AxiosError) => {
   Promise.reject(error);
 };
 
-export const onResponse = (response: AxiosResponse) => {
-  const defaultServerScheme: DefaultServerResponseType = response.data;
+export const onResponse = <T>(response: AxiosResponse<DefaultServerResponseType<T>>) => {
+  const defaultServerScheme: DefaultServerResponseType<T> = response.data;
   const { data, statusCode, success } = defaultServerScheme;
   const { headers } = response;
   return { ...data, headers, statusCode, success };

--- a/src/api/config/interceptor.ts
+++ b/src/api/config/interceptor.ts
@@ -25,8 +25,10 @@ export const onRequestError = (error: AxiosError) => {
   Promise.reject(error);
 };
 
-export const onResponse = <T>(response: AxiosResponse<DefaultServerResponseType<T>>) => {
-  const defaultServerScheme: DefaultServerResponseType<T> = response.data;
+export const onResponse = <DataType>(
+  response: AxiosResponse<DefaultServerResponseType<DataType>>,
+) => {
+  const defaultServerScheme: DefaultServerResponseType<DataType> = response.data;
   const { data, statusCode, success } = defaultServerScheme;
   const { headers } = response;
   return { ...data, headers, statusCode, success };

--- a/src/mocks/comment/comment.mockHandler.ts
+++ b/src/mocks/comment/comment.mockHandler.ts
@@ -2,59 +2,58 @@ import { rest } from 'msw';
 
 import { ROOT_API_URL } from '~/api/config/requestUrl';
 import { createCommentCount, createCommentList } from '~/mocks/comment/comment.mock';
+import { generateResponse } from '~/mocks/mock.util';
 
 export const commentMockHandler = [
-  rest.get(`${ROOT_API_URL}/id-cards/:idCardId/comments?page=:page&size=10`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL}/id-cards/:idCardId/comments?page=:page&size=10`, req => {
     const { searchParams } = req.url;
     const page = Number(searchParams.get('page'));
     const idCardId = Number(req.url.pathname.split('/')[3]);
+    return generateResponse({
+      statusCode: 200,
+      data: { data: createCommentList(10, page, 10, idCardId) },
+    });
+  }),
+  rest.get(`${ROOT_API_URL}/id-cards/:idCardId/comments-count`, () => {
+    return generateResponse({ statusCode: 200, data: createCommentCount() });
+  }),
+  rest.post(`${ROOT_API_URL}/id-cards/:idCardId/comments`, () => {
+    return generateResponse({ statusCode: 200, data: { id: 1 } });
+  }),
+  rest.delete(`${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId`, () => {
+    return generateResponse({ statusCode: 200, data: { id: 1 } });
+  }),
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        data: createCommentList(10, page, 10, idCardId),
-      }),
-    );
-  }),
-  rest.get(`${ROOT_API_URL}/id-cards/:idCardId/comments-count`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(createCommentCount()));
-  }),
-  rest.post(`${ROOT_API_URL}/id-cards/:idCardId/comments`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ id: 1 }));
-  }),
-  rest.delete(`${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ id: 1 }));
-  }),
-  rest.post(`${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId/replies`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ id: 1 }));
+  rest.post(`${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId/replies`, () => {
+    return generateResponse({ statusCode: 200, data: { id: 1 } });
   }),
   // DELETE reply
   rest.delete(
     `${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId/replies/:commentReplyId`,
-    (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json({ id: 1 }));
+    () => {
+      return generateResponse({ statusCode: 200, data: { id: 1 } });
     },
   ),
   // POST Like
-  rest.post(`${ROOT_API_URL}/id-cards/:idCardsId/comments/:commentId/likes`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ id: 1 }));
+  rest.post(`${ROOT_API_URL}/id-cards/:idCardsId/comments/:commentId/likes`, () => {
+    return generateResponse({ statusCode: 200, data: { id: 1 } });
   }),
   // POST reply Like
   rest.post(
     `${ROOT_API_URL}/id-cards/:idCardsId/comments/:commentId/replies/:commentReplyId/reply-likes`,
-    (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json({ id: 1 }));
+    () => {
+      return generateResponse({ statusCode: 200, data: { id: 1 } });
     },
   ),
   // DELETE Like
-  rest.delete(`${ROOT_API_URL}/id-cards/:idCardsId/comments/:commentId/likes`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ id: 1 }));
+  rest.delete(`${ROOT_API_URL}/id-cards/:idCardsId/comments/:commentId/likes`, () => {
+    return generateResponse({ statusCode: 200, data: { id: 1 } });
   }),
   // DELETE reply Like
   rest.delete(
     `${ROOT_API_URL}/id-cards/:idCardsId/comments/:commentId/replies/:commentReplyId/reply-likes`,
-    (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json({ id: 1 }));
+    () => {
+      return generateResponse({ statusCode: 200, data: { id: 1 } });
     },
   ),
 ];

--- a/src/mocks/community/community.mockHandler.ts
+++ b/src/mocks/community/community.mockHandler.ts
@@ -6,28 +6,29 @@ import {
   createCommunityIdCards,
   createCommunityList,
 } from '~/mocks/community/community.mock';
+import { generateResponse } from '~/mocks/mock.util';
 
 export const communityMockHandler = [
-  rest.get(
-    `${ROOT_API_URL}/communities/:communityId/idCards?page=:page&size=10`,
-    (req, res, ctx) => {
-      const { searchParams } = req.url;
-      const page = Number(searchParams.get('page'));
-
-      return res(
-        ctx.status(200),
-        ctx.json({
-          communityIdCardsDtos: createCommunityIdCards(10, page, 10),
-        }),
-      );
-    },
-  ),
-
-  rest.get(`${ROOT_API_URL}/communities/:communityId`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ communityDetailsDto: createCommunityDetail() }));
+  rest.get(`${ROOT_API_URL}/communities/:communityId/idCards?page=:page&size=10`, req => {
+    const { searchParams } = req.url;
+    const page = Number(searchParams.get('page'));
+    return generateResponse({
+      statusCode: 200,
+      data: { communityIdCardsDtos: createCommunityIdCards(10, page, 10) },
+    });
   }),
 
-  rest.get(`${ROOT_API_URL}/communities/users/:userId`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ communityListDtos: createCommunityList() }));
+  rest.get(`${ROOT_API_URL}/communities/:communityId`, () => {
+    return generateResponse({
+      statusCode: 200,
+      data: { communityDetailsDto: createCommunityDetail() },
+    });
+  }),
+
+  rest.get(`${ROOT_API_URL}/communities/users/:userId`, () => {
+    return generateResponse({
+      statusCode: 200,
+      data: { communityListDtos: createCommunityList() },
+    });
   }),
 ];

--- a/src/mocks/idCard/idCard.mockHandler.ts
+++ b/src/mocks/idCard/idCard.mockHandler.ts
@@ -2,18 +2,19 @@ import { rest } from 'msw';
 
 import { ROOT_API_URL } from '~/api/config/requestUrl';
 import { createIdCardMock, idCardDetailMock } from '~/mocks/idCard/idCard.mock';
+import { generateResponse } from '~/mocks/mock.util';
 
 export const idCardMockHandler = [
-  rest.get(`${ROOT_API_URL}/id-cards/:idCardId`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ idCardDetailsDto: idCardDetailMock() }));
+  rest.get(`${ROOT_API_URL}/id-cards/:idCardId`, () => {
+    return generateResponse({ statusCode: 200, data: { idCardDetailsDto: idCardDetailMock() } });
   }),
-  rest.get(`${ROOT_API_URL}/communities/:communityId/users/idCards`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ idCardDetailsDto: idCardDetailMock() }));
+  rest.get(`${ROOT_API_URL}/communities/:communityId/users/idCards`, () => {
+    return generateResponse({ statusCode: 200, data: { idCardDetailsDto: idCardDetailMock() } });
   }),
-  rest.put(`${ROOT_API_URL}/id-cards/:idCardId`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(idCardDetailMock()));
+  rest.put(`${ROOT_API_URL}/id-cards/:idCardId`, () => {
+    return generateResponse({ statusCode: 200, data: idCardDetailMock() });
   }),
-  rest.post(`${ROOT_API_URL}/id-cards`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(createIdCardMock));
+  rest.post(`${ROOT_API_URL}/id-cards`, () => {
+    return generateResponse({ statusCode: 200, data: createIdCardMock });
   }),
 ];

--- a/src/mocks/image/image.mockHandler.ts
+++ b/src/mocks/image/image.mockHandler.ts
@@ -1,11 +1,12 @@
 import { rest } from 'msw';
 
 import { ROOT_API_URL } from '~/api/config/requestUrl';
+import { generateResponse } from '~/mocks/mock.util';
 
 import { imageUrlMock } from './image.mock';
 
 export const imageMockHandler = [
-  rest.post(`${ROOT_API_URL}/images`, (req, res, ctx) =>
-    res(ctx.status(200), ctx.json(imageUrlMock)),
-  ),
+  rest.post(`${ROOT_API_URL}/images`, () => {
+    return generateResponse({ statusCode: 200, data: imageUrlMock });
+  }),
 ];

--- a/src/mocks/mock.util.ts
+++ b/src/mocks/mock.util.ts
@@ -2,11 +2,11 @@ import { context, response } from 'msw';
 
 import { DefaultServerResponseType } from '~/api/config/api.types';
 
-export const generateResponse = ({
+export const generateResponse = <DataType>({
   data,
   statusCode,
   delay = 0,
-}: Omit<DefaultServerResponseType, 'success'> & { delay?: number }) => {
+}: Omit<DefaultServerResponseType<DataType>, 'success'> & { delay?: number }) => {
   const isSuccess = statusCode < 400;
   return response(
     context.status(200),

--- a/src/mocks/mock.util.ts
+++ b/src/mocks/mock.util.ts
@@ -1,0 +1,20 @@
+import { context, response } from 'msw';
+
+import { DefaultServerResponseType } from '~/api/config/api.types';
+
+export const generateResponse = ({
+  data,
+  statusCode,
+  delay = 0,
+}: Omit<DefaultServerResponseType, 'success'> & { delay?: number }) => {
+  const isSuccess = statusCode < 400;
+  return response(
+    context.status(200),
+    context.delay(delay),
+    context.json({
+      data,
+      statusCode,
+      success: isSuccess,
+    }),
+  );
+};

--- a/src/mocks/notification/notification.mockHandler.ts
+++ b/src/mocks/notification/notification.mockHandler.ts
@@ -1,18 +1,17 @@
 import { rest } from 'msw';
 
 import { ROOT_API_URL } from '~/api/config/requestUrl';
+import { generateResponse } from '~/mocks/mock.util';
 
 import { createNotificationList } from './notification.mock';
 
 export const notificationMockHandler = [
-  rest.get(`${ROOT_API_URL}/notifications?page=:page&size=10`, (req, res, ctx) => {
+  rest.get(`${ROOT_API_URL}/notifications?page=:page&size=10`, req => {
     const { searchParams } = req.url;
     const page = Number(searchParams.get('page'));
-    return res(
-      ctx.status(200),
-      ctx.json({
-        data: createNotificationList(10, page, 10),
-      }),
-    );
+    return generateResponse({
+      statusCode: 200,
+      data: { data: createNotificationList(10, page, 10) },
+    });
   }),
 ];

--- a/src/mocks/user/user.mockHandler.ts
+++ b/src/mocks/user/user.mockHandler.ts
@@ -1,13 +1,14 @@
 import { rest } from 'msw';
 
 import { ROOT_API_URL } from '~/api/config/requestUrl';
+import { generateResponse } from '~/mocks/mock.util';
 import { createUserInfo } from '~/mocks/user/user.mock';
 
 export const userMockHandler = [
-  rest.get(`${ROOT_API_URL}/user/profile`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(createUserInfo()));
+  rest.get(`${ROOT_API_URL}/user/profile`, () => {
+    return generateResponse({ statusCode: 200, data: createUserInfo() });
   }),
-  rest.post(`${ROOT_API_URL}/user/character`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({}));
+  rest.post(`${ROOT_API_URL}/user/character`, () => {
+    return generateResponse({ statusCode: 200, data: {} });
   }),
 ];


### PR DESCRIPTION
### ⛳️ Task

1. 아래와 같은 서버 기본 타입을 추가했어요. 

```tsx
export type DefaultServerResponseType = {
  data: any;
  statusCode: number;
  success: boolean;
};
```

intercptor의 onResponse에서는 아래와 같이 parsing해요~

논의대로 서버에서 내려주는 statusCode, success를 사용합니당

```tsx

export const onResponse = (response: AxiosResponse) => {
  const defaultServerScheme: DefaultServerResponseType = response.data;
  const { data, statusCode, success } = defaultServerScheme;
  const { headers } = response;
  return { ...data, headers, statusCode, success };
};
```

2. mock handler 기본 유틸 response

`src/mocks/mock.util.ts` 에 있습니다

```diff
- return res(ctx.status(200), ctx.json(createCommentCount()));
+ return generateResponse({ statusCode: 200, data: createCommentCount() });
```


### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
