### PR TITLE
Dep 176 delete comment

### DIFF
--- a/src/api/domain/comment.api.ts
+++ b/src/api/domain/comment.api.ts
@@ -38,6 +38,7 @@ import {
   createNewComment,
   createNewReply,
   removeCommentToPages,
+  removeReplyToPages,
   updateCommentId,
   updateReplyId,
 } from '~/utils/commentApi.util';
@@ -203,7 +204,28 @@ export const useDeleteReply = (idCardId: number) => {
 
   return useMutation({
     mutationFn: (replyInfo: CommentReplyDeleteRequest) => deleteReply(replyInfo),
-    onSuccess: () => queryClient.invalidateQueries(commentQueryKey.comments(idCardId)),
+    onMutate: async (replyInfo: CommentReplyDeleteRequest) => {
+      await queryClient.cancelQueries({ queryKey: commentQueryKey.comments(idCardId) });
+
+      const previousComments = queryClient.getQueryData<CommentPages>(
+        commentQueryKey.comments(idCardId),
+      );
+
+      const updatedComments = removeReplyToPages(
+        previousComments,
+        replyInfo.commentId,
+        replyInfo.commentReplyId,
+      );
+      queryClient.setQueryData(commentQueryKey.comments(idCardId), updatedComments);
+
+      return { previousComments };
+    },
+    onError: (err, newComment, context) => {
+      if (context?.previousComments) {
+        // TODO: toast error
+        queryClient.setQueryData(commentQueryKey.comments(idCardId), context.previousComments);
+      }
+    },
   });
 };
 

--- a/src/api/domain/comment.api.ts
+++ b/src/api/domain/comment.api.ts
@@ -37,6 +37,7 @@ import {
   CommentPages,
   createNewComment,
   createNewReply,
+  removeCommentToPages,
   updateCommentId,
   updateReplyId,
 } from '~/utils/commentApi.util';
@@ -124,7 +125,24 @@ export const useDeleteComment = (idCardId: number) => {
 
   return useMutation({
     mutationFn: (commentInfo: CommentDeleteRequest) => deleteComment(commentInfo),
-    onSuccess: () => queryClient.invalidateQueries(commentQueryKey.comments(idCardId)),
+    onMutate: async (commentInfo: CommentDeleteRequest) => {
+      await queryClient.cancelQueries({ queryKey: commentQueryKey.comments(idCardId) });
+
+      const previousComments = queryClient.getQueryData<CommentPages>(
+        commentQueryKey.comments(idCardId),
+      );
+
+      const updatedComments = removeCommentToPages(previousComments, commentInfo.commentId);
+      queryClient.setQueryData(commentQueryKey.comments(idCardId), updatedComments);
+
+      return { previousComments };
+    },
+    onError: (err, newComment, context) => {
+      if (context?.previousComments) {
+        // TODO: toast error
+        queryClient.setQueryData(commentQueryKey.comments(idCardId), context.previousComments);
+      }
+    },
   });
 };
 

--- a/src/modules/CommentList/Comment/Comment.client.tsx
+++ b/src/modules/CommentList/Comment/Comment.client.tsx
@@ -2,7 +2,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { useState } from 'react';
 
-import { useDeleteCommentLike, usePostLikeComment } from '~/api/domain/comment.api';
+import {
+  useDeleteComment,
+  useDeleteCommentLike,
+  usePostLikeComment,
+} from '~/api/domain/comment.api';
 import {
   Content,
   DeleteButton,
@@ -68,6 +72,12 @@ export const Comment = ({
     setIsShowReplyList(false);
   };
 
+  const { mutate: mutateDeleteComment } = useDeleteComment(idCardId);
+
+  const onClickToDeleteComment = () => {
+    mutateDeleteComment({ idCardId, commentId });
+  };
+
   return (
     <li className="flex w-full gap-12pxr px-layout-sm">
       <UserProfile profileImageUrl={profileImageUrl} />
@@ -79,7 +89,11 @@ export const Comment = ({
             <div className="mt-8pxr flex gap-16pxr">
               <LikeCount likeCount={likeCount} />
               <ReplySubmitButton nickname={nickname} commentId={commentId} />
-              {userId === writerId ? <DeleteButton /> : <ReportButton />}
+              {userId === writerId ? (
+                <DeleteButton onClickToDeleteComment={onClickToDeleteComment} />
+              ) : (
+                <ReportButton />
+              )}
             </div>
           </div>
           <div>

--- a/src/modules/CommentList/CommentCommon/DeleteButton.client.tsx
+++ b/src/modules/CommentList/CommentCommon/DeleteButton.client.tsx
@@ -1,11 +1,15 @@
 import { useConfirmPopup } from '~/components/ConfirmPopup';
 import { ConfirmDeleteComment } from '~/components/ConfirmPopup/ConfirmDeleteComment';
 
-export const DeleteButton = () => {
+type DeleteButtonProps = {
+  onClickToDeleteComment: () => void;
+};
+
+export const DeleteButton = ({ onClickToDeleteComment }: DeleteButtonProps) => {
   const { isOpen, openPopup, closePopup, confirm } = useConfirmPopup();
 
   const deleteComment = () => {
-    // TODO: 삭제로직 추가하기
+    onClickToDeleteComment();
   };
 
   const onDeleteComment = async () => {

--- a/src/modules/CommentList/CommentReplyList/CommentReply.client.tsx
+++ b/src/modules/CommentList/CommentReplyList/CommentReply.client.tsx
@@ -1,7 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 'use client';
 
-import { useDeleteCommentReplyLike, usePostLikeCommentReply } from '~/api/domain/comment.api';
+import {
+  useDeleteCommentReplyLike,
+  useDeleteReply,
+  usePostLikeCommentReply,
+} from '~/api/domain/comment.api';
 import {
   Content,
   DeleteButton,
@@ -56,6 +60,12 @@ export const CommentReply = ({
     mutateDeleteLike.mutate({ idCardId, commentId, commentReplyId });
   };
 
+  const { mutate: mutateDeleteReply } = useDeleteReply(idCardId);
+
+  const onClickToDeleteComment = () => {
+    mutateDeleteReply({ idCardId, commentId, commentReplyId });
+  };
+
   return (
     <li className="flex w-full gap-12pxr px-[calc(layout-sm+42px)]">
       <UserProfile profileImageUrl={profileImageUrl} />
@@ -67,7 +77,11 @@ export const CommentReply = ({
             <div className="mt-8pxr flex gap-16pxr">
               <LikeCount likeCount={likeCount} />
               <ReplySubmitButton nickname={nickname} commentId={commentId} />
-              {userId === writerId ? <DeleteButton /> : <ReportButton />}
+              {userId === writerId ? (
+                <DeleteButton onClickToDeleteComment={onClickToDeleteComment} />
+              ) : (
+                <ReportButton />
+              )}
             </div>
           </div>
           <div>

--- a/src/utils/commentApi.util.ts
+++ b/src/utils/commentApi.util.ts
@@ -220,3 +220,39 @@ export const removeCommentToPages = (
     pageParams: previousComments?.pageParams ?? [],
   };
 };
+
+export const removeReplyToPages = (
+  previousComments: CommentPages | undefined,
+  commentId: number,
+  replyId: number,
+) => {
+  const copyPreviousComments = _.cloneDeep(previousComments);
+  const pages = copyPreviousComments?.pages ? copyPreviousComments.pages : [];
+
+  const updatedPages = pages.map(page => {
+    const updatedData = {
+      ...page.data,
+      content: page.data.content.map(comment => {
+        if (comment.commentId !== commentId) {
+          return comment;
+        }
+        const updatedReplies = comment.commentReplyInfos.filter(
+          reply => reply.commentReplyId !== replyId,
+        );
+        return {
+          ...comment,
+          commentReplyInfos: updatedReplies,
+        };
+      }),
+    };
+    return {
+      ...page,
+      data: updatedData,
+    };
+  });
+
+  return {
+    pages: updatedPages,
+    pageParams: previousComments?.pageParams ?? [],
+  };
+};

--- a/src/utils/commentApi.util.ts
+++ b/src/utils/commentApi.util.ts
@@ -196,3 +196,27 @@ export const updateReplyId = (
     pageParams: previousComments?.pageParams ?? [],
   };
 };
+
+export const removeCommentToPages = (
+  previousComments: CommentPages | undefined,
+  commentId: number,
+) => {
+  const copyPreviousComments = _.cloneDeep(previousComments);
+  const pages = copyPreviousComments?.pages ? copyPreviousComments.pages : [];
+
+  const updatedPages = pages.map(page => {
+    const updatedData = {
+      ...page.data,
+      content: page.data.content.filter(comment => comment.commentId !== commentId),
+    };
+    return {
+      ...page,
+      data: updatedData,
+    };
+  });
+
+  return {
+    pages: updatedPages,
+    pageParams: previousComments?.pageParams ?? [],
+  };
+};


### PR DESCRIPTION
### ⛳️ Task
댓글, 대댓글 삭제를 구현했어요.

### ✍️ Note
저번 회의 때 언급했지만, 로직이 좀 복잡해요..
자세한 로직(commentApi.util.ts)보다는 큰 로직위주(comment.api.ts)로 봐주세요!

1. 댓글 삭제
2. 성공시 => X
3. 실패시 => 롤백

----
저번에 댓글 삭제, 대댓글 삭제 컴포넌트를 분리한다고 했는데 코드 중복되는게 있어서, 컴포넌트에 함수를 넘겨주도록 구현해서 코드 중복을 줄였어요. 


### ⚡️ Test
`pnpm msw // 실행`

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
