### PR TITLE
feat: 중복 체크 api 추가

### DIFF
--- a/src/api/domain/community.api.ts
+++ b/src/api/domain/community.api.ts
@@ -6,6 +6,7 @@ import {
   CommunityDetailResponse,
   CommunityIdCardsResponse,
   CommunityListResponse,
+  CommunityNameCheckResponse,
   CommunityUpdateResponse,
 } from '~/types/community';
 import { CommunityIdCardsRequest, CreateCommunityRequest } from '~/types/community/request.type';
@@ -82,3 +83,10 @@ export const usePostCommunityUpdate = (communityId: number) => {
     },
   });
 };
+
+export const checkCommunityName = (communityName: string) =>
+  privateApi.get<CommunityNameCheckResponse>('/communities/check', {
+    params: {
+      name: communityName,
+    },
+  });

--- a/src/modules/CommunityAdmin/CommunityAdminEditForm.client.tsx
+++ b/src/modules/CommunityAdmin/CommunityAdminEditForm.client.tsx
@@ -1,6 +1,7 @@
 import { UseMutationResult } from '@tanstack/react-query';
 import { useFormContext } from 'react-hook-form';
 
+import { checkCommunityName } from '~/api/domain/community.api';
 import { Button } from '~/components/Button';
 import { ProfileImageEdit } from '~/components/ProfileImageEdit';
 import { TextArea, useTextArea } from '~/components/TextArea';
@@ -34,6 +35,7 @@ export const CommunityAdminEditForm = ({
     setValue,
     handleSubmit,
     formState: { defaultValues },
+    getValues,
   } = useFormContext<CreateCommunityRequest>();
 
   const defaultPlanetLogoImage =
@@ -49,10 +51,9 @@ export const CommunityAdminEditForm = ({
     maxLength: TEXT_AREA_MAX_LENGTH,
   });
 
-  const onCheck = () => {
-    //TODO: 중복확인 로직 추가
-    setIsDuplicatedCheck('SUCCESS');
-    // setIsDuplicatedCheck('ERROR');
+  const onCheck = async () => {
+    const check = await checkCommunityName(getValues('name'));
+    setIsDuplicatedCheck(check.data ? 'ERROR' : 'SUCCESS');
   };
 
   const onClickTitle = () => isDuplicatedCheck !== 'DEFAULT' && setIsDuplicatedCheck('DEFAULT');

--- a/src/types/community/response.type.ts
+++ b/src/types/community/response.type.ts
@@ -16,3 +16,7 @@ export type CommunityListResponse = {
 export type CommunityUpdateResponse = {
   id: number;
 };
+
+export type CommunityNameCheckResponse = {
+  data: boolean;
+};


### PR DESCRIPTION
### ⛳️ Task
행성 생성/수정 form에 중복 체크 로직을 추가했어요.
### ✍️ Note 
서버 응답 형태로 원시값이 넘어오는데, 이경우 onResponse에서 {...data}와 같은 방식으로 전달할 수 없기 때문에 interceptor 응답 형태 #134 가 반영되어야 정상 작동합니다.
### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
