### PR TITLE
Fix/sse: 구독 인증 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "axios": "^1.4.0",
     "chromatic": "^6.18.0",
     "eslint-config-next": "13.4.3",
+    "event-source-polyfill": "^1.0.31",
     "framer-motion": "^10.12.16",
     "lodash": "^4.17.21",
     "msw": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@faker-js/faker": "^8.0.2",
     "@tanstack/react-query": "^4.29.7",
     "@tanstack/react-query-devtools": "^4.29.7",
+    "@types/event-source-polyfill": "^1.0.1",
     "@types/node": "20.2.3",
     "@types/react": "18.2.6",
     "@types/react-dom": "18.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@tanstack/react-query-devtools':
     specifier: ^4.29.7
     version: 4.29.7(@tanstack/react-query@4.29.7)(react-dom@18.2.0)(react@18.2.0)
+  '@types/event-source-polyfill':
+    specifier: ^1.0.1
+    version: 1.0.1
   '@types/node':
     specifier: 20.2.3
     version: 20.2.3
@@ -4894,6 +4897,10 @@ packages:
   /@types/estree@1.0.1:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
+
+  /@types/event-source-polyfill@1.0.1:
+    resolution: {integrity: sha512-dls8b0lUgJ/miRApF0efboQ9QZnAm7ofTO6P1ILu8bRPxUFKDxVwFf8+TeuuErmNui6blpltyr7+eV72dbQXlQ==}
+    dev: false
 
   /@types/express-serve-static-core@4.17.35:
     resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   eslint-config-next:
     specifier: 13.4.3
     version: 13.4.3(eslint@8.22.0)(typescript@5.0.4)
+  event-source-polyfill:
+    specifier: ^1.0.31
+    version: 1.0.31
   framer-motion:
     specifier: ^10.12.16
     version: 10.12.16(react-dom@18.2.0)(react@18.2.0)
@@ -7530,6 +7533,10 @@ packages:
     resolution: {integrity: sha512-KB44sV4Mv7uLIkJHJ5qhiZe5um6th2g57nHQL/uqnPHKP2IswoTRWUteEXTJQL4gW++1zqWUni+H2hGkP51c9w==}
     dependencies:
       tslib: 2.5.3
+    dev: false
+
+  /event-source-polyfill@1.0.31:
+    resolution: {integrity: sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==}
     dev: false
 
   /events@3.3.0:

--- a/src/modules/Notification/NewNotificationBadge.client.tsx
+++ b/src/modules/Notification/NewNotificationBadge.client.tsx
@@ -15,9 +15,10 @@ export const NewNotificationBadge = () => {
 
   useEffect(() => {
     const EventSource = EventSourcePolyfill || NativeEventSource;
+    let newNotificationSource: EventSource | null = null;
     const { accessToken } = getAuthTokensByCookie(document.cookie);
     if (!accessToken) return;
-    let newNotificationSource: EventSource | null = null;
+
     newNotificationSource = new EventSource(`${ROOT_API_URL}/notifications/subscribe`, {
       headers: {
         Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
### ⛳️ Task
구독 EventSource에 인증 헤더를 추가했어요.
기본 EventSource는 header를 지원하지 않기 때문에 [폴리필](https://www.npmjs.com/package/event-source-polyfill)을 설치했어요.
### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
