### PR TITLE
Fix main flow cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare": "husky install",
     "sb": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "msw": "NEXT_PUBLIC_API_MOCKING=enabled next dev"
+    "msw": "NEXT_PUBLIC_API_MOCKING=enable next dev"
   },
   "dependencies": {
     "@faker-js/faker": "^8.0.2",

--- a/src/api/domain/community.api.ts
+++ b/src/api/domain/community.api.ts
@@ -104,7 +104,7 @@ export const usePostCommunityUpdate = (communityId: number) => {
 };
 
 export const getInvitationCodeIsValid = async (invitationCode: string) => {
-  return await publicApi.get<InvitationCodeValidationResponse>(`/communities/join`, {
+  return await publicApi.get<InvitationCodeValidationResponse>(`/communities/validate`, {
     params: { code: invitationCode },
   });
 };

--- a/src/api/domain/community.api.ts
+++ b/src/api/domain/community.api.ts
@@ -4,6 +4,7 @@ import {
   UseMutationOptions,
   useQuery,
   useQueryClient,
+  UseQueryOptions,
 } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { useRouter } from 'next/navigation';
@@ -108,9 +109,14 @@ export const getInvitationCodeIsValid = async (invitationCode: string) => {
   });
 };
 
-export const useGetInvitationCodeIsValid = (invitationCode: string) =>
-  useQuery(communityQueryKey.invitationCodeIsValid(), () =>
-    getInvitationCodeIsValid(invitationCode),
+export const useGetInvitationCodeIsValid = (
+  invitationCode: string,
+  options?: UseQueryOptions<InvitationCodeValidationResponse>,
+) =>
+  useQuery<InvitationCodeValidationResponse>(
+    communityQueryKey.invitationCodeIsValid(),
+    () => getInvitationCodeIsValid(invitationCode),
+    options,
   );
 
 export const postCommunityJoin = async (communityId: CommunityJoinRequest) => {

--- a/src/app/Provider.tsx
+++ b/src/app/Provider.tsx
@@ -8,7 +8,7 @@ import { useState } from 'react';
 import { ToastMessageProvider } from '~/components/ToastMessage';
 import initMocks from '~/mocks';
 
-if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
+if (process.env.NEXT_PUBLIC_API_MOCKING === 'enable') {
   initMocks();
 }
 

--- a/src/app/invitation/[code]/page.tsx
+++ b/src/app/invitation/[code]/page.tsx
@@ -15,9 +15,14 @@ const InvitationPage = ({ params }: { params: { code: string } }) => {
   const router = useRouter();
   const invitationCode = params.code;
 
-  // TODO: 잘못된 행성 코드인 경우, 에러 처리(error.page)
+  // TODO: 잘못된 행성 코드인 경우, 에러 메시지 보여주기(후순위)
   const { data: validPlanet, isLoading: isValidPlanetLoading } = useGetInvitationCodeIsValid(
     params.code,
+    {
+      onError: () => {
+        router.replace('/');
+      },
+    },
   );
   const communityId = validPlanet?.communityId;
   const userId = getUserIdClient();

--- a/src/app/invitation/[code]/page.tsx
+++ b/src/app/invitation/[code]/page.tsx
@@ -6,7 +6,8 @@ import { useGetInvitationCodeIsValid, usePostCommunityJoin } from '~/api/domain/
 import { useGetUserInfo } from '~/api/domain/user.api';
 import { Template } from '~/components/Template';
 import { getUserIdClient } from '~/utils/auth/getUserId.client';
-import { STORAGE_REDIRECT_URI_KEY } from '~/utils/route/route';
+import { setCookie } from '~/utils/cookie.util';
+import { ROUTE_COOKIE_KEYS } from '~/utils/route/route';
 
 const title = '당신을 디프만 행성으로\n 초대합니다';
 
@@ -31,8 +32,6 @@ const InvitationPage = ({ params }: { params: { code: string } }) => {
 
   const onClick = async () => {
     if (communityId && userId) {
-      if (window.sessionStorage.getItem(STORAGE_REDIRECT_URI_KEY))
-        window.sessionStorage.removeItem(STORAGE_REDIRECT_URI_KEY);
       await mutateAsync({ communityId });
       if (userInfo?.characterType) {
         router.push(`/planet/${communityId}`);
@@ -40,7 +39,7 @@ const InvitationPage = ({ params }: { params: { code: string } }) => {
         router.push('/onboarding');
       }
     } else {
-      window.sessionStorage.setItem(STORAGE_REDIRECT_URI_KEY, `/invitation/${invitationCode}`);
+      setCookie(ROUTE_COOKIE_KEYS.invitationCode, invitationCode);
       router.push('/auth/signin');
     }
   };

--- a/src/app/invitation/[code]/page.tsx
+++ b/src/app/invitation/[code]/page.tsx
@@ -41,10 +41,11 @@ const InvitationPage = ({ params }: { params: { code: string } }) => {
       if (userInfo?.characterType) {
         router.push(`/planet/${communityId}`);
       } else {
+        setCookie(ROUTE_COOKIE_KEYS.redirectUri, `/planet/${communityId}`);
         router.push('/onboarding');
       }
     } else {
-      setCookie(ROUTE_COOKIE_KEYS.invitationCode, invitationCode);
+      setCookie(ROUTE_COOKIE_KEYS.redirectUri, `/invitation/${invitationCode}`);
       router.push('/auth/signin');
     }
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,42 +1,6 @@
-'use client';
-
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
-
-import { useGetUserInfo } from '~/api/domain/user.api';
-import { getUserIdClient } from '~/utils/auth/getUserId.client';
-import { STORAGE_REDIRECT_URI_KEY } from '~/utils/route/route';
 
 const Home = () => {
-  const router = useRouter();
-  const userId = getUserIdClient();
-  const { data: userInfo } = useGetUserInfo({
-    enabled: !!userId,
-  });
-
-  useEffect(() => {
-    const redirectUri = window.sessionStorage.getItem(STORAGE_REDIRECT_URI_KEY);
-    if (userId) {
-      if (redirectUri) {
-        router.replace(redirectUri);
-      }
-
-      if (userInfo) {
-        const { characterType, communityIds } = userInfo;
-        if (characterType) {
-          communityIds.length > 0
-            ? router.push(`/planet/${communityIds[0]}`)
-            : router.push('/planet');
-        } else {
-          router.push('/onboarding');
-        }
-      }
-    } else {
-      router.push('/auth/signin');
-    }
-  }, [router, userId, userInfo]);
-
   return (
     <main>
       <Image

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,8 @@ import publicApi from '~/api/config/publicApi';
 import { AUTH_COOKIE_KEYS, AuthResponse } from '~/types/auth';
 import { generateCookiesKeyValues } from '~/utils/auth/tokenHandlers';
 
+import { ROUTE_COOKIE_KEYS } from './utils/route/route';
+
 export const ACCESS_TOKEN_EXPIRE_MARGIN_SECOND = 60;
 
 // Authorization이 필요한 페이지 경로를 저장합니다.
@@ -40,6 +42,20 @@ const middleware = async (request: NextRequest) => {
       const communityIds = [1]; // mock data
 
       if (characterType) {
+        const redirectUri = request.cookies.get(ROUTE_COOKIE_KEYS.redirectUri)?.value;
+        if (redirectUri) {
+          const response = NextResponse.redirect(new URL(redirectUri, request.url));
+          response.cookies.delete(ROUTE_COOKIE_KEYS.redirectUri);
+          return response;
+        }
+
+        const invitationCode = request.cookies.get(ROUTE_COOKIE_KEYS.invitationCode)?.value;
+        if (invitationCode) {
+          const response = NextResponse.redirect(new URL(`/planet/${invitationCode}`, request.url));
+          response.cookies.delete(ROUTE_COOKIE_KEYS.invitationCode);
+          return response;
+        }
+
         return communityIds.length > 0
           ? NextResponse.redirect(new URL(`/planet/${communityIds[0]}`, request.url))
           : NextResponse.redirect(new URL('/planet', request.url));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,7 +30,7 @@ const logout = (request: NextRequest) => {
 const middleware = async (request: NextRequest) => {
   const pathname = request.nextUrl.pathname;
 
-  if (pathname.startsWith('/') && pathname.endsWith('/')) {
+  if (pathname === '/') {
     const accessToken = getAccessToken(request);
     if (accessToken) {
       // TO DO: BE 도메인 정상화 이후 복원 + privateApi로 변경
@@ -41,18 +41,17 @@ const middleware = async (request: NextRequest) => {
       const characterType = 'BUDDY'; // mock data
       const communityIds = [1]; // mock data
 
+      const redirectUri = request.cookies.get(ROUTE_COOKIE_KEYS.redirectUri)?.value;
+      if (redirectUri?.includes('invitation')) {
+        const response = NextResponse.redirect(new URL(redirectUri, request.url));
+        response.cookies.delete(ROUTE_COOKIE_KEYS.redirectUri);
+        return response;
+      }
+
       if (characterType) {
-        const redirectUri = request.cookies.get(ROUTE_COOKIE_KEYS.redirectUri)?.value;
         if (redirectUri) {
           const response = NextResponse.redirect(new URL(redirectUri, request.url));
           response.cookies.delete(ROUTE_COOKIE_KEYS.redirectUri);
-          return response;
-        }
-
-        const invitationCode = request.cookies.get(ROUTE_COOKIE_KEYS.invitationCode)?.value;
-        if (invitationCode) {
-          const response = NextResponse.redirect(new URL(`/planet/${invitationCode}`, request.url));
-          response.cookies.delete(ROUTE_COOKIE_KEYS.invitationCode);
           return response;
         }
 

--- a/src/mocks/community/community.mockHandler.ts
+++ b/src/mocks/community/community.mockHandler.ts
@@ -17,24 +17,28 @@ export const communityMockHandler = [
       data: { communityIdCardsDtos: createCommunityIdCards(10, page, 10) },
     });
   }),
-
-  rest.get(`${ROOT_API_URL}/communities/:communityId`, () => {
+  rest.get(`${ROOT_API_URL}/communities/validate`, () => {
     return generateResponse({
       statusCode: 200,
-      data: { communityDetailsDto: createCommunityDetail() },
+      data: { communityId: 1 },
     });
   }),
-
   rest.get(`${ROOT_API_URL}/communities/users/:userId`, () => {
     return generateResponse({
       statusCode: 200,
       data: { communityListDtos: createCommunityList() },
     });
   }),
-  rest.get(`${ROOT_API_URL}/communities/validate?code=:code`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ communityId: 1 }));
+  rest.post(`${ROOT_API_URL}/communities/join`, () => {
+    return generateResponse({
+      statusCode: 200,
+      data: {},
+    });
   }),
-  rest.post(`${ROOT_API_URL}/communities/join`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({}));
+  rest.get(`${ROOT_API_URL}/communities/:communityId`, () => {
+    return generateResponse({
+      statusCode: 200,
+      data: { communityDetailsDto: createCommunityDetail() },
+    });
   }),
 ];

--- a/src/modules/Onboarding/Step/CharacterCompleteStep.client.tsx
+++ b/src/modules/Onboarding/Step/CharacterCompleteStep.client.tsx
@@ -55,12 +55,6 @@ export const CharacterCompleteStep = ({ characterName }: CharacterCompleteStepPr
       return router.push(redirectUri);
     }
 
-    const invitationCode = getCookie(ROUTE_COOKIE_KEYS.invitationCode);
-    if (invitationCode) {
-      deleteCookie(ROUTE_COOKIE_KEYS.invitationCode);
-      return router.push(`/planet/${invitationCode}`);
-    }
-
     return communityIds && communityIds.length > 0
       ? router.push(`/planet/${communityIds[0]}`)
       : router.push('/planet');

--- a/src/utils/auth/getUserId.server.ts
+++ b/src/utils/auth/getUserId.server.ts
@@ -4,7 +4,7 @@ import { AUTH_COOKIE_KEYS } from '~/types/auth';
 
 import { UserIdNotFoundError } from './error';
 
-export const getUserIdServer = (): number => {
+export const getUserIdServer = (): number | undefined => {
   try {
     const cookieStore = cookies();
     const userId = cookieStore.get(AUTH_COOKIE_KEYS.userId)?.value;
@@ -13,6 +13,6 @@ export const getUserIdServer = (): number => {
     if (isNaN(userIdNumber)) throw new UserIdNotFoundError();
     return userIdNumber;
   } catch (e) {
-    return -1;
+    return undefined;
   }
 };

--- a/src/utils/cookie.util.ts
+++ b/src/utils/cookie.util.ts
@@ -1,0 +1,33 @@
+// Ref : https://ko.javascript.info/cookie
+
+export const getCookie = (name: string) => {
+  const matches = document.cookie.match(
+    // eslint-disable-next-line no-useless-escape
+    new RegExp('(?:^|; )' + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + '=([^;]*)'),
+  );
+  return matches ? decodeURIComponent(matches[1]) : undefined;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const setCookie = (name: string, value: any, options?: any) => {
+  const cookieOptions = {
+    ...options,
+  };
+
+  let updatedCookie = encodeURIComponent(name) + '=' + encodeURIComponent(value);
+
+  for (const optionKey in cookieOptions) {
+    updatedCookie += '; ' + optionKey;
+    const optionValue = cookieOptions[optionKey];
+    if (optionValue !== true) {
+      updatedCookie += '=' + optionValue;
+    }
+  }
+  document.cookie = updatedCookie;
+};
+
+export const deleteCookie = (name: string) => {
+  setCookie(name, '', {
+    'max-age': -1,
+  });
+};

--- a/src/utils/cookie.util.ts
+++ b/src/utils/cookie.util.ts
@@ -11,6 +11,7 @@ export const getCookie = (name: string) => {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const setCookie = (name: string, value: any, options?: any) => {
   const cookieOptions = {
+    path: '/',
     ...options,
   };
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,14 +1,14 @@
 import { ROOT_API_URL } from '~/api/config/requestUrl';
 
-export const getFetch = async (path: string, headers?: RequestInit['headers']) => {
+export const getFetch = async (path: string, requestConfig?: RequestInit) => {
   const url = `${ROOT_API_URL}${path}`;
   const options: RequestInit = {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
-      ...headers,
     },
     credentials: 'include',
+    ...requestConfig,
   };
   const res = await fetch(url, options);
   const data = await res.json();

--- a/src/utils/route/route.ts
+++ b/src/utils/route/route.ts
@@ -1,4 +1,3 @@
 export const ROUTE_COOKIE_KEYS = {
   redirectUri: 'redirectUri',
-  invitationCode: 'invitationCode',
 };

--- a/src/utils/route/route.ts
+++ b/src/utils/route/route.ts
@@ -1,1 +1,4 @@
-export const STORAGE_REDIRECT_URI_KEY = 'redirectUri';
+export const ROUTE_COOKIE_KEYS = {
+  redirectUri: 'redirectUri',
+  invitationCode: 'invitationCode',
+};


### PR DESCRIPTION
### ⛳️ Task

- msw가 개발 환경에서만 돌도록 환경변수를 수정합니다.
- "로그인 후 이전 페이지로 돌아가기" 또는 "초대페이지로 들어올 시 해당 초대코드의 행성으로 보내기"를 구현하기 위해 cookie를 사용
- cookie를 다루는 함수 util을 추가합니다.
- 초대 페이지와 onboarding 페이지에 쿠키 및 routing logic을 추가합니다.
- 초대코드가 유효하지 않을 때 에러를 처리합니다.


### ⚡️ Test

[Notion](https://www.notion.so/depromeet/834d9f5f03fb4d57885d91d7c3b0f88a)에 테스트 시나리오 적어놓았습니다.

### 📎 Reference
[miro](https://miro.com/app/board/uXjVM7tyQlc=/)
