### PR TITLE
#157 기본 추천 키워드 관리

### DIFF
--- a/src/constant/recommendKeyword.ts
+++ b/src/constant/recommendKeyword.ts
@@ -1,0 +1,59 @@
+import { OptionType } from '~/components/KeywordInput';
+
+export const DEFAULT_RECOMMEND_KEYWORD_OPTIONS: OptionType[] = [
+  {
+    title: '밤 산책',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '아메리카노',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '해외 축구',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '음악',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '공포영화',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '셀프 인테리어',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '엽떡',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '우주 맛집 투어',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '필름카메라',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '강아지 영상보기',
+    imageUrl: '',
+    content: '',
+  },
+  {
+    title: '오버워치',
+    imageUrl: '',
+    content: '',
+  },
+];

--- a/src/modules/IdCardCreation/Step/KeywordStep.client.tsx
+++ b/src/modules/IdCardCreation/Step/KeywordStep.client.tsx
@@ -2,7 +2,8 @@
 
 import { Controller, useFormContext } from 'react-hook-form';
 
-import { KeywordInput, OptionType } from '~/components/KeywordInput';
+import { KeywordInput } from '~/components/KeywordInput';
+import { DEFAULT_RECOMMEND_KEYWORD_OPTIONS } from '~/constant/recommendKeyword';
 import { IdCardCreationFormModel } from '~/types/idCard';
 
 const title = '이웃 주민에게 자신을 소개할\n 키워드를 적어주세요!';
@@ -22,7 +23,7 @@ export const KeywordStep = () => {
             placeholder="1개 이상의 키워드를 추가해주세요."
             keywordLabel="이런 키워드는 어때요?"
             activeKeywordList={value}
-            keywordOptions={TEMP_RECOMMEND_KEYWORD_LIST}
+            keywordOptions={DEFAULT_RECOMMEND_KEYWORD_OPTIONS}
             onChange={onChange} // rhf onchange handler
             maxActiveKeywordListLength={7}
             maxInputLength={8}
@@ -33,36 +34,3 @@ export const KeywordStep = () => {
     </div>
   );
 };
-
-const TEMP_RECOMMEND_KEYWORD_LIST: OptionType[] = [
-  {
-    title: '재치 발랄',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: '엽기 떡볶이',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: '맛집투어',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: 'FE 짱짱',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: '7팀 최고',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: '디프만 최고~',
-    imageUrl: '',
-    content: '',
-  },
-];

--- a/src/modules/IdCardEditor/IdCardEditor.constant.ts
+++ b/src/modules/IdCardEditor/IdCardEditor.constant.ts
@@ -1,4 +1,3 @@
-import { OptionType } from '~/components/KeywordInput';
 import { EditorSteps } from '~/modules/IdCardEditor/IdCardEditor.type';
 
 // 순서가 있지는 않음. KEYWORD_CONTENT: 최초 진인접, / PROFILE, KEYWORD은 같은 깊이
@@ -13,36 +12,3 @@ export const MAX_KEYWORD_LIST_LENGTH = 7;
 export const MAX_KEYWORD_INPUT_LENGTH = 8;
 export const MAX_NICKNAME_LENGTH = 16;
 export const MAX_ABOUT_ME_LENGTH = 50;
-
-export const TEMP_RECOMMEND_KEYWORD_LIST: OptionType[] = [
-  {
-    title: '재치 발랄',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: '엽기 떡볶이',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: '맛집투어',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: 'FE 짱짱',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: '7팀 최고',
-    imageUrl: '',
-    content: '',
-  },
-  {
-    title: '디프만 최고~',
-    imageUrl: '',
-    content: '',
-  },
-];

--- a/src/modules/IdCardEditor/Step/EditKeywordStep.client.tsx
+++ b/src/modules/IdCardEditor/Step/EditKeywordStep.client.tsx
@@ -1,10 +1,10 @@
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { KeywordInput } from '~/components/KeywordInput';
+import { DEFAULT_RECOMMEND_KEYWORD_OPTIONS } from '~/constant/recommendKeyword';
 import {
   MAX_KEYWORD_INPUT_LENGTH,
   MAX_KEYWORD_LIST_LENGTH,
-  TEMP_RECOMMEND_KEYWORD_LIST,
 } from '~/modules/IdCardEditor/IdCardEditor.constant';
 import { IdCardEditorFormValues } from '~/modules/IdCardEditor/IdCardEditor.type';
 
@@ -23,7 +23,7 @@ export const EditKeywordStep = () => {
             placeholder="1개 이상의 키워드를 추가해주세요."
             keywordLabel="이런 키워드는 어때요?"
             activeKeywordList={value}
-            keywordOptions={TEMP_RECOMMEND_KEYWORD_LIST}
+            keywordOptions={DEFAULT_RECOMMEND_KEYWORD_OPTIONS}
             onChange={onChange}
             maxActiveKeywordListLength={MAX_KEYWORD_LIST_LENGTH}
             maxInputLength={MAX_KEYWORD_INPUT_LENGTH}


### PR DESCRIPTION
### ⛳️ Task

주민증 생성 및 주민증 수정에서 사용하는 추천 키워드 constant화

client에서 관리합니당. 선택된 캐릭터마다 다른 추천키워드가 아닌 어떤 유저이든 동일한 추천키워드가 보여지도록 합니다

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference

https://github.com/depromeet/Ding-dong-fe/issues/157