### PR TITLE
행성만들기 steps에서 communityId추가

### DIFF
--- a/src/app/planet/[communityId]/id-card/create/page.tsx
+++ b/src/app/planet/[communityId]/id-card/create/page.tsx
@@ -1,9 +1,13 @@
-import 'server-only';
-
 import { IdCardCreationSteps } from '~/modules/IdCardCreation';
 
-const IdCardCreationPage = () => {
-  return <IdCardCreationSteps />;
+type IdCardCreationPageProps = {
+  params: {
+    communityId: string;
+  };
+};
+
+const IdCardCreationPage = ({ params: { communityId } }: IdCardCreationPageProps) => {
+  return <IdCardCreationSteps communityId={Number(communityId)} />;
 };
 
 export default IdCardCreationPage;

--- a/src/modules/IdCardCreation/IdCardCreationSteps.tsx
+++ b/src/modules/IdCardCreation/IdCardCreationSteps.tsx
@@ -8,7 +8,6 @@ import * as yup from 'yup';
 import { usePostIdCardCreate } from '~/api/domain/idCard.api';
 import { IdCardCreationForm } from '~/modules/IdCardCreation/Form';
 import { BoardingStep, CompleteStep } from '~/modules/IdCardCreation/Step';
-import { useCommunityStore } from '~/stores/community.store';
 import { IdCardCreationFormModel } from '~/types/idCard';
 
 import { CreationSteps } from './IdCardCreation.type';
@@ -23,12 +22,14 @@ const schema = yup.object({
   keywords: yup.array().min(1).default([]).required(),
 });
 
-export const IdCardCreationSteps = () => {
-  const { communityId } = useCommunityStore();
+type IdCardCreationStepsProps = {
+  communityId: number;
+};
 
+export const IdCardCreationSteps = ({ communityId }: IdCardCreationStepsProps) => {
   const methods = useForm<IdCardCreationFormModel>({
     defaultValues: {
-      communityId: communityId,
+      communityId,
       profileImageUrl: '',
       nickname: '',
       aboutMe: '',


### PR DESCRIPTION
### ⛳️ Task

행성만들기 steps에서 communityId추가

- 변경된 폴더 구조에 따라 IdCardCreationSteps의 props로 communityId를 넘겨 받도록 수정했어요

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

<img width="1332" alt="스크린샷 2023-07-02 오후 4 36 32" src="https://github.com/depromeet/Ding-dong-fe/assets/71386219/e6f73d91-4245-4f19-a4ec-8495616095e8">


| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference

https://github.com/depromeet/Ding-dong-fe/issues/153