### PR TITLE
Add object-cover css on profile user image

### DIFF
--- a/src/modules/CommentList/CommentCommon/UserProfile.client.tsx
+++ b/src/modules/CommentList/CommentCommon/UserProfile.client.tsx
@@ -7,7 +7,13 @@ type UserProfileProps = Pick<CommentWriterIntoModel, 'profileImageUrl'>;
 export const UserProfile = ({ profileImageUrl }: UserProfileProps) => {
   return (
     <div className="h-32pxr w-32pxr flex-shrink-0 overflow-hidden rounded-full">
-      <Image width={32} height={32} src={profileImageUrl} alt="profile image" />
+      <Image
+        width={32}
+        height={32}
+        src={profileImageUrl}
+        className="object-cover"
+        alt="profile image"
+      />
     </div>
   );
 };


### PR DESCRIPTION
### ⛳️ Task

- profile image에 `object-cover` css를 추가합니다.

### Screenshot
![image](https://github.com/depromeet/Ding-dong-fe/assets/55529617/b1c45d58-9b8a-4c31-b003-b581a219f456)


### 📎 Reference
#261