### PR TITLE
대댓글 API 관련 변경 사항 반영 (대댓글 요청을 댓글 요청과 분리)

### DIFF
--- a/src/api/domain/comment/comment.api.ts
+++ b/src/api/domain/comment/comment.api.ts
@@ -40,6 +40,8 @@ import {
   CommentPostRequest,
   CommentPostResponse,
   CommentReplyDeleteRequest,
+  CommentReplyGetRequest,
+  CommentReplyGetResponse,
   CommentReplyLikeCancelDeleteResponse,
   CommentReplyLikeCancelRequest,
   CommentReplyLikePostResponse,
@@ -49,6 +51,7 @@ import { CommunityUserInfoResponse } from '~/types/community';
 
 export const commentQueryKey = {
   comments: (idCardId: number) => ['comments', idCardId],
+  commentReplies: (idCardId: number, commentId: number) => ['replies', idCardId, commentId],
   commentCount: (idCardId: number) => ['commentCount', idCardId],
 };
 
@@ -75,6 +78,14 @@ export const getCommentCounts = ({ idCardId }: CommentCountGetRequest) =>
 
 export const useGetCommentCounts = ({ idCardId }: CommentCountGetRequest) =>
   useQuery(commentQueryKey.commentCount(idCardId), () => getCommentCounts({ idCardId }));
+
+export const getCommentReplies = ({ idCardId, commentId }: CommentReplyGetRequest) =>
+  privateApi.get<CommentReplyGetResponse>(`/id-cards/${idCardId}/comments/${commentId}/replies`);
+
+export const useGetCommentReplies = ({ idCardId, commentId }: CommentReplyGetRequest) =>
+  useQuery(commentQueryKey.commentCount(idCardId), () =>
+    getCommentReplies({ idCardId, commentId }),
+  );
 
 export const postCommentCreate = ({ idCardId, contents }: CommentPostRequest) =>
   privateApi.post<CommentPostResponse>(`id-cards/${idCardId}/comments`, { contents });

--- a/src/api/domain/comment/comment.api.ts
+++ b/src/api/domain/comment/comment.api.ts
@@ -10,7 +10,8 @@ import { AxiosError } from 'axios';
 import privateApi from '~/api/config/privateApi';
 import {
   addCommentToPages,
-  addReplyToPages,
+  addReplyCountToPages,
+  addReplyToComment,
   CommentPages,
   createNewComment,
   createNewReply,

--- a/src/api/domain/comment/comment.api.ts
+++ b/src/api/domain/comment/comment.api.ts
@@ -278,7 +278,8 @@ export const usePostReplyCreate = (idCardId: number, communityId: number) => {
 
       queryClient.setQueryData<CommentReplyGetResponse | undefined>(
         commentQueryKey.commentReplies(idCardId, commentId),
-        previousComments => updateReplyId(commentId, replyId, previousComments),
+        previousCommentRepliesResponse =>
+          updateReplyId(commentId, replyId, previousCommentRepliesResponse),
       );
     },
   });

--- a/src/api/domain/comment/comment.helper.ts
+++ b/src/api/domain/comment/comment.helper.ts
@@ -176,9 +176,9 @@ export const addReplyCountToPages = (
 export const updateReplyId = (
   commentId: number,
   replyId: number,
-  previousComments?: CommentReplyGetResponse,
+  previousCommentRepliesResponse?: CommentReplyGetResponse,
 ): CommentReplyGetResponse => {
-  const copyPreviousCommentReplies = cloneDeep(previousComments?.repliesInfo || []);
+  const copyPreviousCommentReplies = cloneDeep(previousCommentRepliesResponse?.repliesInfo || []);
 
   const updated = copyPreviousCommentReplies.map(reply => {
     if (reply.commentReplyId === replyId) {

--- a/src/mocks/comment/comment.mock.ts
+++ b/src/mocks/comment/comment.mock.ts
@@ -23,11 +23,9 @@ export const createCommentReply = (idx: number): CommentReplyModel => ({
       to: '2023-08-31T00:00:00.000Z',
     })
     .toLocaleString(),
+  writerInfo: createCommentWriter(idx),
   commentReplyLikeInfo: createCommentLike(),
 });
-
-export const createCommentReplyList = (n: number) =>
-  Array.from({ length: n }, (_, idx) => createCommentReply(Number(`${idx}${idx}`)));
 
 export const createComment = (idCardId: number, idx: number): CommentModel => ({
   idCardId,
@@ -41,8 +39,19 @@ export const createComment = (idCardId: number, idx: number): CommentModel => ({
     .toLocaleString(),
   writerInfo: createCommentWriter(idx),
   commentLikeInfo: createCommentLike(),
-  commentReplyInfos: createCommentReplyList(faker.number.int({ min: 0, max: 100 })),
+  repliesCount: faker.number.int({ min: 0, max: 999 }),
 });
+
+export const createCommentCount = () => ({
+  count: faker.number.int({ min: 0, max: 999 }),
+});
+
+export const createRandomId = () => ({
+  id: faker.number.int({ min: 0, max: 999 }),
+});
+
+export const createCommentReplyList = (n: number) =>
+  Array.from({ length: n }, (_, idx) => createCommentReply(Number(`${idx}${idx}`)));
 
 export const createCommentList = (
   n: number,
@@ -54,12 +63,4 @@ export const createCommentList = (
   page,
   size,
   hasNext: page === 5,
-});
-
-export const createCommentCount = () => ({
-  count: faker.number.int({ min: 0, max: 999 }),
-});
-
-export const createRandomId = () => ({
-  id: faker.number.int({ min: 0, max: 999 }),
 });

--- a/src/mocks/comment/comment.mockHandler.ts
+++ b/src/mocks/comment/comment.mockHandler.ts
@@ -1,14 +1,17 @@
+import { faker } from '@faker-js/faker/locale/ko';
 import { rest } from 'msw';
 
 import { ROOT_API_URL } from '~/api/config/requestUrl';
 import {
   createCommentCount,
   createCommentList,
+  createCommentReplyList,
   createRandomId,
 } from '~/mocks/comment/comment.mock';
 import { generateResponse } from '~/mocks/mock.util';
 
 export const commentMockHandler = [
+  // GET Comment
   rest.get(`${ROOT_API_URL}/id-cards/:idCardId/comments?page=:page&size=10`, req => {
     const { searchParams } = req.url;
     const page = Number(searchParams.get('page'));
@@ -18,20 +21,33 @@ export const commentMockHandler = [
       data: createCommentList(10, page, 10, idCardId),
     });
   }),
+  // GET Comment count
   rest.get(`${ROOT_API_URL}/id-cards/:idCardId/comment-count`, () => {
     return generateResponse({ statusCode: 200, data: createCommentCount() });
   }),
+  rest.get(`${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId/replies`, req => {
+    const commentId = Number(req.url.pathname.split('/')[5]);
+    return generateResponse({
+      statusCode: 200,
+      data: {
+        commentId,
+        repliesInfo: createCommentReplyList(faker.number.int({ min: 0, max: 30 })),
+      },
+    });
+  }),
+  // POST comment
   rest.post(`${ROOT_API_URL}/id-cards/:idCardId/comments`, () => {
     return generateResponse({ statusCode: 200, data: createRandomId() });
   }),
+  // DELETE comment
   rest.delete(`${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId`, () => {
     return generateResponse({ statusCode: 200, data: createRandomId() });
   }),
-
+  // POST Reply
   rest.post(`${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId/replies`, () => {
     return generateResponse({ statusCode: 200, data: createRandomId() });
   }),
-  // DELETE reply
+  // DELETE Reply
   rest.delete(
     `${ROOT_API_URL}/id-cards/:idCardId/comments/:commentId/replies/:commentReplyId`,
     () => {

--- a/src/mocks/user/user.mockHandler.ts
+++ b/src/mocks/user/user.mockHandler.ts
@@ -6,7 +6,12 @@ import { createUserInfo } from '~/mocks/user/user.mock';
 
 export const userMockHandler = [
   rest.get(`${ROOT_API_URL}/user/profile`, () => {
-    return generateResponse({ statusCode: 200, data: createUserInfo() });
+    return generateResponse({
+      statusCode: 200,
+      data: {
+        userProfileDto: createUserInfo(),
+      },
+    });
   }),
   rest.post(`${ROOT_API_URL}/user/character`, () => {
     return generateResponse({ statusCode: 200, data: {} });

--- a/src/modules/CommentList/Comment/Comment.client.tsx
+++ b/src/modules/CommentList/Comment/Comment.client.tsx
@@ -34,7 +34,7 @@ export const Comment = ({
   createdAt,
   writerInfo,
   commentLikeInfo,
-  commentReplyInfos,
+  repliesCount,
 }: CommentProps) => {
   const { errorToast } = useToastMessageStore();
   const { userId: writerId, profileImageUrl, nickname } = writerInfo;
@@ -109,14 +109,12 @@ export const Comment = ({
         <ReplyShowButton
           isShowReplyList={isShowReplyList}
           onClickShowReplyList={onClickShowReplyList}
-          commentReplyInfos={commentReplyInfos}
+          repliesCount={repliesCount}
         />
         <CommentReplyList
           idCardId={idCardId}
           commentId={commentId}
-          writerInfo={writerInfo}
           isShowReplyList={isShowReplyList}
-          commentReplyInfos={commentReplyInfos}
         />
         <div className="mt-24pxr">
           <ReplyHideButton

--- a/src/modules/CommentList/Comment/Comment.client.tsx
+++ b/src/modules/CommentList/Comment/Comment.client.tsx
@@ -1,5 +1,4 @@
 'use client';
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { useState } from 'react';
 
 import {
@@ -8,22 +7,20 @@ import {
   usePostLikeComment,
 } from '~/api/domain/comment/comment.api';
 import {
+  CommentOptions,
   Content,
-  DeleteButton,
   Header,
   LikeCount,
   LikeIcon,
   ReplyHideButton,
   ReplyShowButton,
   ReplySubmitButton,
-  ReportButton,
   UserProfile,
 } from '~/modules/CommentList/CommentCommon';
 import { CommentReplyList } from '~/modules/CommentList/CommentReplyList';
 import { useLike } from '~/modules/CommentList/useLike';
 import { useToastMessageStore } from '~/stores/toastMessage.store';
 import { CommentModel } from '~/types/comment';
-import { getUserIdClient } from '~/utils/auth/getUserId.client';
 
 type CommentProps = CommentModel;
 
@@ -37,11 +34,11 @@ export const Comment = ({
   repliesCount,
 }: CommentProps) => {
   const { errorToast } = useToastMessageStore();
-  const { userId: writerId, profileImageUrl, nickname } = writerInfo;
+  const { profileImageUrl, nickname } = writerInfo;
   const [isShowReplyList, setIsShowReplyList] = useState(false);
   const { isLikedByCurrentUser, likeCount, likeComment, cancelLikeComment } =
     useLike(commentLikeInfo);
-  const userId = getUserIdClient();
+
   const mutatePostLike = usePostLikeComment({
     onError: error => {
       errorToast(error.message);
@@ -88,14 +85,13 @@ export const Comment = ({
         <div className="flex w-full gap-12pxr">
           <div className="w-full">
             <Content content={content} />
-            <div className="mt-8pxr flex gap-16pxr">
+            <div className="mt-8pxr flex items-center gap-16pxr">
               <LikeCount likeCount={likeCount} />
               <ReplySubmitButton nickname={nickname} commentId={commentId} />
-              {userId === writerId ? (
-                <DeleteButton onClickToDeleteComment={onClickToDeleteComment} />
-              ) : (
-                <ReportButton />
-              )}
+              <CommentOptions
+                writerInfo={writerInfo}
+                onClickToDeleteComment={onClickToDeleteComment}
+              />
             </div>
           </div>
           <div>

--- a/src/modules/CommentList/CommentCommon/CommentOptions.client.tsx
+++ b/src/modules/CommentList/CommentCommon/CommentOptions.client.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { DeleteButton } from '~/modules/CommentList/CommentCommon/DeleteButton.client';
+import { ReportButton } from '~/modules/CommentList/CommentCommon/ReportButton.client';
+import { CommentModel } from '~/types/comment';
+import { getUserIdClient } from '~/utils/auth/getUserId.client';
+
+type CommentOptionsProps = Pick<CommentModel, 'writerInfo'> & {
+  onClickToDeleteComment: VoidFunction;
+};
+
+export const CommentOptions = ({ writerInfo, onClickToDeleteComment }: CommentOptionsProps) => {
+  const { userId: writerId } = writerInfo;
+  const userId = getUserIdClient();
+
+  const [isMine, setIsMine] = useState(false);
+
+  const isWriterSameAsUser = userId === writerId;
+
+  // Text content does not match server-rendered HTML 이슈로 useEffect로 분리처리
+  useEffect(() => {
+    setIsMine(isWriterSameAsUser);
+  }, [isWriterSameAsUser, userId, writerId]);
+
+  return (
+    <>
+      {isMine ? <DeleteButton onClickToDeleteComment={onClickToDeleteComment} /> : <ReportButton />}
+    </>
+  );
+};

--- a/src/modules/CommentList/CommentCommon/ReplyShowButton.client.tsx
+++ b/src/modules/CommentList/CommentCommon/ReplyShowButton.client.tsx
@@ -1,7 +1,7 @@
 import { DashIcon } from '~/components/Icon';
 import { CommentModel } from '~/types/comment';
 
-type ReplyShowButtonProps = Pick<CommentModel, 'commentReplyInfos'> & {
+type ReplyShowButtonProps = Pick<CommentModel, 'repliesCount'> & {
   isShowReplyList: boolean;
   onClickShowReplyList: VoidFunction;
 };
@@ -9,9 +9,9 @@ type ReplyShowButtonProps = Pick<CommentModel, 'commentReplyInfos'> & {
 export const ReplyShowButton = ({
   isShowReplyList,
   onClickShowReplyList,
-  commentReplyInfos,
+  repliesCount,
 }: ReplyShowButtonProps) => {
-  const isReplyListEmpty = commentReplyInfos.length === 0;
+  const isReplyListEmpty = repliesCount === 0;
 
   const isShowButton = !isShowReplyList && !isReplyListEmpty;
 
@@ -21,7 +21,7 @@ export const ReplyShowButton = ({
         <button type="button" onClick={onClickShowReplyList} className="mt-24pxr flex gap-8pxr">
           <DashIcon className="fill-grey-500" />
           <span className="text-detail font-semibold text-grey-500">
-            답글 {commentReplyInfos.length}개 더보기
+            답글 {repliesCount}개 더보기
           </span>
         </button>
       )}

--- a/src/modules/CommentList/CommentCommon/index.ts
+++ b/src/modules/CommentList/CommentCommon/index.ts
@@ -1,3 +1,4 @@
+export * from './CommentOptions.client';
 export * from './Content.client';
 export * from './DeleteButton.client';
 export * from './Empty.client';

--- a/src/modules/CommentList/CommentReplyList/CommentReply.client.tsx
+++ b/src/modules/CommentList/CommentReplyList/CommentReply.client.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 'use client';
 
 import {
@@ -7,19 +6,17 @@ import {
   usePostLikeCommentReply,
 } from '~/api/domain/comment/comment.api';
 import {
+  CommentOptions,
   Content,
-  DeleteButton,
   Header,
   LikeCount,
   LikeIcon,
   ReplySubmitButton,
-  ReportButton,
   UserProfile,
 } from '~/modules/CommentList/CommentCommon';
 import { useLike } from '~/modules/CommentList/useLike';
 import { useToastMessageStore } from '~/stores/toastMessage.store';
 import { CommentModel, CommentReplyModel } from '~/types/comment';
-import { getUserIdClient } from '~/utils/auth/getUserId.client';
 
 type CommentProps = Pick<CommentModel, 'idCardId' | 'commentId' | 'writerInfo'> & CommentReplyModel;
 
@@ -33,10 +30,9 @@ export const CommentReply = ({
   commentReplyLikeInfo,
 }: CommentProps) => {
   const { errorToast } = useToastMessageStore();
-  const { userId: writerId, profileImageUrl, nickname } = writerInfo;
+  const { profileImageUrl, nickname } = writerInfo;
   const { isLikedByCurrentUser, likeCount, likeComment, cancelLikeComment } =
     useLike(commentReplyLikeInfo);
-  const userId = getUserIdClient();
 
   const mutatePostLike = usePostLikeCommentReply({
     onError: error => {
@@ -76,14 +72,13 @@ export const CommentReply = ({
         <div className="flex w-full gap-12pxr">
           <div className="w-full">
             <Content content={content} />
-            <div className="mt-8pxr flex gap-16pxr">
+            <div className="mt-8pxr flex items-center gap-16pxr">
               <LikeCount likeCount={likeCount} />
               <ReplySubmitButton nickname={nickname} commentId={commentId} />
-              {userId === writerId ? (
-                <DeleteButton onClickToDeleteComment={onClickToDeleteComment} />
-              ) : (
-                <ReportButton />
-              )}
+              <CommentOptions
+                writerInfo={writerInfo}
+                onClickToDeleteComment={onClickToDeleteComment}
+              />
             </div>
           </div>
           <div>

--- a/src/modules/CommentList/CommentReplyList/CommentReplyList.client.tsx
+++ b/src/modules/CommentList/CommentReplyList/CommentReplyList.client.tsx
@@ -1,33 +1,48 @@
+'use client';
+import { Suspense } from 'react';
+
+import { useGetCommentReplies } from '~/api/domain/comment/comment.api';
+import RetryErrorBoundary from '~/components/ErrorBoundary/RetryErrorBoundary.client';
 import { CommentReply } from '~/modules/CommentList/CommentReplyList/CommentReply.client';
 import { CommentModel } from '~/types/comment';
 
-type CommentReplyListProps = Pick<
-  CommentModel,
-  'commentReplyInfos' | 'idCardId' | 'commentId' | 'writerInfo'
-> & {
+type CommentReplyListProps = Pick<CommentModel, 'idCardId' | 'commentId'> & {
   isShowReplyList: boolean;
 };
+const CommentReplyListComponent = ({ idCardId, commentId }: CommentReplyListProps) => {
+  const { data } = useGetCommentReplies({ idCardId, commentId });
+  const commentReplyList = data?.repliesInfo;
+  return (
+    <ul className="mt-24pxr flex flex-col gap-24pxr">
+      {commentReplyList?.map(commentReply => (
+        <CommentReply
+          key={commentReply.commentReplyId}
+          idCardId={idCardId}
+          commentId={commentId}
+          {...commentReply}
+        />
+      ))}
+    </ul>
+  );
+};
+
 export const CommentReplyList = ({
   idCardId,
   commentId,
-  commentReplyInfos,
   isShowReplyList,
-  writerInfo,
 }: CommentReplyListProps) => {
   return (
     <>
       {isShowReplyList && (
-        <ul className="mt-24pxr flex flex-col gap-24pxr">
-          {commentReplyInfos.map(commentReply => (
-            <CommentReply
-              key={commentReply.commentReplyId}
+        <RetryErrorBoundary>
+          <Suspense>
+            <CommentReplyListComponent
               idCardId={idCardId}
               commentId={commentId}
-              writerInfo={writerInfo}
-              {...commentReply}
+              isShowReplyList={isShowReplyList}
             />
-          ))}
-        </ul>
+          </Suspense>
+        </RetryErrorBoundary>
       )}
     </>
   );

--- a/src/types/comment/model.type.ts
+++ b/src/types/comment/model.type.ts
@@ -9,13 +9,6 @@ export type CommentWriterIntoModel = {
   profileImageUrl: string;
 };
 
-export type CommentReplyModel = {
-  commentReplyId: number;
-  content: string;
-  createdAt: string;
-  commentReplyLikeInfo: CommentLikeModel;
-};
-
 export type CommentModel = {
   idCardId: number;
   commentId: number;
@@ -23,5 +16,13 @@ export type CommentModel = {
   createdAt: string;
   writerInfo: CommentWriterIntoModel;
   commentLikeInfo: CommentLikeModel;
-  commentReplyInfos: CommentReplyModel[];
+  repliesCount: number;
+};
+
+export type CommentReplyModel = {
+  commentReplyId: number;
+  content: string;
+  createdAt: string;
+  writerInfo: CommentWriterIntoModel;
+  commentReplyLikeInfo: CommentLikeModel;
 };

--- a/src/types/comment/request.type.ts
+++ b/src/types/comment/request.type.ts
@@ -7,6 +7,11 @@ export type CommentCountGetRequest = {
   idCardId: number;
 };
 
+export type CommentReplyGetRequest = {
+  idCardId: number;
+  commentId: number;
+};
+
 export type CommentPostRequest = {
   idCardId: number;
   contents: string;

--- a/src/types/comment/response.type.ts
+++ b/src/types/comment/response.type.ts
@@ -1,10 +1,15 @@
 import { SliceResponse } from '~/types/api';
-import { CommentModel } from '~/types/comment/model.type';
+import { CommentModel, CommentReplyModel } from '~/types/comment/model.type';
 
 export type CommentGetResponse = SliceResponse<CommentModel>;
 
 export type CommentCountGetResponse = {
   count: number;
+};
+
+export type CommentReplyGetResponse = {
+  commentId: number;
+  repliesInfo: CommentReplyModel[];
 };
 
 export type CommentPostResponse = {


### PR DESCRIPTION
### ⛳️ Task

1. 댓글 조회와 대댓글 조회 분리
2. 대댓글 작성 낙관적 업데이트 수정
3. 대댓글 제거 낙관적 업데이트 수정

### ✍️ Note

1. 댓글 조회와 대댓글 조회 분리

댓글 스키마에 포함된 대댓글이 별도의 API 요청으로 분리됐어요. 

- 댓글 스키마의 repliesCount가 0 이상일 때만 [답글 더보기] 버튼이 보여져요
- [답글 더보기] 버튼을 눌러서 `src/modules/CommentList/CommentReplyList/CommentReplyList.client.tsx`가 마운트되면 대댓글 요청을 보내요.

2. 대댓글 작성 낙관적 업데이트 수정

요청
- 대댓글을 생성하여 해당 댓글의 대댓글 목록을 업데이트
- 해당 댓글의 대댓글 개수 업데이트

성공
- 대댓글의 id를 실제 서버의 id로 변경

실패
- 이전 대댓글 리스트로 수정
- 이전 댓글의 대댓글 개수로 수정

3. 대댓글 제거 낙관적 업데이트 수정

요청
- 해당 대댓글을 대댓글 목록에서 제거
- 해당 댓글의 대댓글 개수 업데이트

실패
- 이전 대댓글 리스트로 수정
- 이전 댓글의 대댓글 개수로 수정

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference

- [[FE] 작성한 댓글 실시간 업데이트](https://www.notion.so/depromeet/FE-072b3456b9cd41dd834f5c60112eb3e5?pvs=4)
- [[FE] 작성한 댓글 노출](https://www.notion.so/depromeet/FE-0d5d805d89614073a7f7cd29aaac0005?pvs=4)
