### PR TITLE
Fix: mypage에서 주민증 상세보기 되도록 수정

### DIFF
--- a/src/modules/IdCard/IdCard.client.tsx
+++ b/src/modules/IdCard/IdCard.client.tsx
@@ -36,7 +36,7 @@ export const IdCard = ({
   const pathname = usePathname();
 
   const handleClickIdCard = () => {
-    const planetIdPathname = pathname.replace('/id-card/create', '');
+    const planetIdPathname = pathname.replace('/id-card/create', '').replace('/my-page', '/planet');
     router.push(`${planetIdPathname}/id-card/${idCardId}`);
   };
 


### PR DESCRIPTION
### ⛳️ Task
mypage에서 주민증 누르면 주민증 상세보기 되도록 수정하였습니다.

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
https://www.notion.so/depromeet/FE-585f47056b9246b395b478f7b455d2a4?pvs=4