### PR TITLE
Fix running CI and chromatic only when commits are pushed on main

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,10 +4,11 @@
 name: 'Chromatic'
 
 # Event for the workflow
-on:
-  pull_request:
-    branches:
-      - main
+# Temporarily disable features for rapid development
+# on:
+#   pull_request:
+#     branches:
+#       - main
 
 # List of jobs
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,8 @@
 name: 'ci'
 
 on:
-  pull_request:
-    branches: [main, DEP-32-fe-github-action-script]
   push:
-    branches: [main, DEP-32-fe-github-action-script]
+    branches: [main]
 
 env:
   CACHED_DEPENDENCY_PATHS: ${{ github.workspace }}/node_modules


### PR DESCRIPTION
### ⛳️ Task

- pull request가 열릴 때 배포되는 것을 막습니다.
(ec2가 FE, BE 같이 배포할 때 폭파되기 때문에 QA 동안 배포가 많이 일어나는 관계로  CI/CD 조건을 줄이는 것이 목적)


### 📎 Reference
[Slack](https://depromeet13th.slack.com/archives/C0515CGG9H8/p1689000627053719)