### PR TITLE
refactor: 주민증 수정 form 제출 이벤트 막기

### DIFF
--- a/src/modules/IdCardEditor/Form/IdCardEditorForm.tsx
+++ b/src/modules/IdCardEditor/Form/IdCardEditorForm.tsx
@@ -1,4 +1,4 @@
-import { useFormContext } from 'react-hook-form';
+import { FormEvent } from 'react';
 
 import { EditorSteps } from '~/modules/IdCardEditor/IdCardEditor.type';
 import {
@@ -6,12 +6,11 @@ import {
   EditKeywordStep,
   EditProfileInfoStep,
 } from '~/modules/IdCardEditor/Step';
-import { IdCardEditorFormModel } from '~/types/idCard';
 
 type IdCardEditorFormProps = {
   steps: EditorSteps[];
   stepOrder: number;
-  onSubmit: (data: IdCardEditorFormModel) => Promise<void>;
+
   onClickMoveTargetStep: (targetStep: EditorSteps) => void;
 };
 
@@ -19,12 +18,9 @@ export const IdCardEditorForm = ({
   steps,
   stepOrder,
   onClickMoveTargetStep,
-  onSubmit,
 }: IdCardEditorFormProps) => {
-  const { handleSubmit } = useFormContext<IdCardEditorFormModel>();
-
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={(e: FormEvent<HTMLFormElement>) => e.preventDefault()}>
       {steps[stepOrder] === 'KEYWORD_CONTENT' && (
         <EditKeywordContentStep onClickMoveTargetStep={onClickMoveTargetStep} />
       )}

--- a/src/modules/IdCardEditor/IdCardEditor.tsx
+++ b/src/modules/IdCardEditor/IdCardEditor.tsx
@@ -153,7 +153,6 @@ export const IdCardEditor = ({ communityId }: IdCardEditorProps) => {
               steps={editorSteps}
               stepOrder={stepOrder}
               onClickMoveTargetStep={onClickMoveTargetStep}
-              onSubmit={onSubmit}
             />
           </div>
         )}


### PR DESCRIPTION
### ⛳️ Task

[모바일 환경] 키워드 입력 부분에서 enter 버튼을 누르면 form이 제출되는 버그 수정

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference


- [ [FE] 주민증 수정 - 키워드 직접 입력 오류](https://www.notion.so/depromeet/FE-59e464fb14cd49a19a052a89a3af1f01?pvs=4)