### PR TITLE
[FE] 현재 행성이 아닌 다른 행성명이 타이틀에 노출됨

### DIFF
--- a/src/modules/PlanetSelector/PlanetSelector.client.tsx
+++ b/src/modules/PlanetSelector/PlanetSelector.client.tsx
@@ -43,26 +43,29 @@ export const PlanetSelector = () => {
     return lastCommunity.communityId;
   }, [INIT_PLANET_ID, communityList?.communityListDtos]);
 
-  const switchPlanetIdByPathname = useCallback(() => {
-    const isSamePlanetIdFromPathname = (pathPlanetId: number) => pathPlanetId === communityId;
+  const switchPlanetIdByPathname = useCallback(
+    (planetId?: number) => {
+      const isSamePlanetIdFromPathname = (pathPlanetId: number) => pathPlanetId === planetId;
 
-    const planetId = extractPlanetIdFromPathname(pathname);
+      const pathPlanetId = extractPlanetIdFromPathname(pathname);
 
-    if (!planetId) {
-      const lastPlanetId = getLastPlanetId();
-      switchCommunity(lastPlanetId);
-      return;
-    }
+      if (!pathPlanetId) {
+        const lastPlanetId = getLastPlanetId();
+        switchCommunity(lastPlanetId);
+        return;
+      }
 
-    if (isSamePlanetIdFromPathname(planetId)) {
-      return;
-    }
+      if (isSamePlanetIdFromPathname(pathPlanetId)) {
+        return;
+      }
 
-    switchCommunity(planetId);
-  }, [extractPlanetIdFromPathname, pathname, switchCommunity, communityId, getLastPlanetId]);
+      switchCommunity(pathPlanetId);
+    },
+    [extractPlanetIdFromPathname, pathname, switchCommunity, getLastPlanetId],
+  );
 
   useEffect(() => {
-    switchPlanetIdByPathname();
+    switchPlanetIdByPathname(communityId);
   }, [pathname, communityId, switchPlanetIdByPathname]);
 
   const defaultCommunity = communityList?.communityListDtos.find(

--- a/src/modules/PlanetSelector/PlanetSelector.client.tsx
+++ b/src/modules/PlanetSelector/PlanetSelector.client.tsx
@@ -62,9 +62,6 @@ export const PlanetSelector = () => {
   }, [extractPlanetIdFromPathname, pathname, switchCommunity, communityId, getLastPlanetId]);
 
   useEffect(() => {
-    if (communityId !== -1) {
-      return;
-    }
     switchPlanetIdByPathname();
   }, [pathname, communityId, switchPlanetIdByPathname]);
 

--- a/src/utils/cookie.util.ts
+++ b/src/utils/cookie.util.ts
@@ -1,10 +1,12 @@
 // Ref : https://ko.javascript.info/cookie
 
 export const getCookie = (name: string) => {
-  const matches = document.cookie.match(
-    // eslint-disable-next-line no-useless-escape
-    new RegExp('(?:^|; )' + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + '=([^;]*)'),
-  );
+  const matches =
+    typeof window !== 'undefined' &&
+    document.cookie.match(
+      // eslint-disable-next-line no-useless-escape
+      new RegExp('(?:^|; )' + name.replace(/([\.$?*|{}\(\)\[\]\\\/\+^])/g, '\\$1') + '=([^;]*)'),
+    );
   return matches ? decodeURIComponent(matches[1]) : undefined;
 };
 


### PR DESCRIPTION
### ⛳️ Task

무조건 pathname 기반으로 행성 셀렉터에서 행성이 선택되게 수정했어요. 

- 현재 경로의 plaenet Id와 pathname의 plaenet Id이 같으면 실행하지 않아요.
- 전역 스토어로 관리되는 planetId와 pathname의 plaenet Id이 다르면 전역 스토어의 planetid를 수정해요

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
