### PR TITLE
Add moving complete step of idcard creation after backward

### DIFF
--- a/src/api/domain/idCard.api.ts
+++ b/src/api/domain/idCard.api.ts
@@ -37,8 +37,15 @@ export const useGetIdCardDetail = (
 export const getCommunityMyIdCardDetail = (communityId: number) =>
   privateApi.get<CommunityMyIdCardDetailResponse>(`/communities/${communityId}/users/idCards`);
 
-export const useGetCommunityMyIdCardDetail = (communityId: number) =>
-  useQuery(idCardQueryKey.myCommunity(communityId), () => getCommunityMyIdCardDetail(communityId));
+export const useGetCommunityMyIdCardDetail = (
+  communityId: number,
+  options?: UseQueryOptions<CommunityMyIdCardDetailResponse>,
+) =>
+  useQuery<CommunityMyIdCardDetailResponse>(
+    idCardQueryKey.myCommunity(communityId),
+    () => getCommunityMyIdCardDetail(communityId),
+    options,
+  );
 
 export const editIdCardDetail = (idCardInfo: EditIdCardRequest) => {
   const { idCardId, profileImageUrl, nickname, aboutMe, keywords } = idCardInfo;


### PR DESCRIPTION
### ⛳️ Task

- 원인 : 하나의 url에서 step으로 관리하고 있었기 때문입니다.
- 해결 : 해당 url로 들어왔을 때, 주민증 생성 여부를 체크하고 완료 step으로 보냅니다.

### 📸 Screenshot
![Jul-13-2023 01-15-52](https://github.com/depromeet/Ding-dong-fe/assets/55529617/b0afc610-411d-4312-87ec-a85e163b4e98)


### 📎 Reference
[Notion](https://www.notion.so/depromeet/FE-b96c0fb92e0847cc81e36279541bd43f)