### PR TITLE
알림 페이지 이동후 다시 홈으로 돌아오면, 원래 있던 행성이 아닌, 행성 목록 중 첫 번째 행성으로 이동합니다

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -20,6 +20,13 @@ export const BottomNavigation = () => {
     router.push(path);
   };
 
+  const getPlanetId = () => {
+    const pathPlanetId = extractPlanetIdFromPathname(pathname);
+    if (pathPlanetId) return pathPlanetId;
+    if (!isInitPlanetId()) return planetId;
+    return null;
+  };
+
   const getSvgColor = (bottomNavigationPath: BottomNavigationPath) => {
     if (pathname.includes(bottomNavigationPath)) {
       return 'fill-primary-500 stroke-primary-500';
@@ -29,28 +36,25 @@ export const BottomNavigation = () => {
   };
 
   const onClickHome = () => {
-    const pathPlanetId = extractPlanetIdFromPathname(pathname);
-    if (pathPlanetId) {
-      handleNavigation(`/planet/${pathPlanetId}`);
+    const targetPlanetId = getPlanetId();
+    if (targetPlanetId) {
+      handleNavigation(`/planet/${targetPlanetId}`);
       return;
     }
-    if (!isInitPlanetId()) {
-      handleNavigation(`/planet/${planetId}`);
-      return;
-    }
-
     handleNavigation('/');
   };
-  const onClickNotification = () => {
-    handleNavigation('/notification');
-  };
+
   const onClickMyPage = () => {
-    const planetId = extractPlanetIdFromPathname(pathname);
-    if (planetId) {
-      handleNavigation(`/my-page/${planetId}`);
+    const targetPlanetId = getPlanetId();
+    if (targetPlanetId) {
+      handleNavigation(`/my-page/${targetPlanetId}`);
       return;
     }
     handleNavigation('/my-page');
+  };
+
+  const onClickNotification = () => {
+    handleNavigation('/notification');
   };
 
   return (

--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -6,6 +6,7 @@ import { Divider } from '~/components/Divider';
 import { BellIcon, HomeIcon, PersonIcon } from '~/components/Icon';
 import { usePlanetNavigate } from '~/hooks/usePlanetNavigate';
 import { NewNotificationBadge } from '~/modules/Notification/NewNotificationBadge.client';
+import { useCommunityStore } from '~/stores/community.store';
 
 type BottomNavigationPath = '/planet' | '/notification' | '/my-page' | '/';
 
@@ -13,6 +14,7 @@ export const BottomNavigation = () => {
   const pathname = usePathname();
   const router = useRouter();
   const { extractPlanetIdFromPathname } = usePlanetNavigate();
+  const { communityId: planetId, isInitPlanetId } = useCommunityStore();
 
   const handleNavigation = (path: string) => {
     router.push(path);
@@ -27,11 +29,16 @@ export const BottomNavigation = () => {
   };
 
   const onClickHome = () => {
-    const planetId = extractPlanetIdFromPathname(pathname);
-    if (planetId) {
+    const pathPlanetId = extractPlanetIdFromPathname(pathname);
+    if (pathPlanetId) {
+      handleNavigation(`/planet/${pathPlanetId}`);
+      return;
+    }
+    if (!isInitPlanetId()) {
       handleNavigation(`/planet/${planetId}`);
       return;
     }
+
     handleNavigation('/');
   };
   const onClickNotification = () => {

--- a/src/stores/community.store.ts
+++ b/src/stores/community.store.ts
@@ -3,14 +3,19 @@ import { create } from 'zustand';
 type Store = {
   communityId: number;
   switchCommunity: (id: number) => void;
+  isInitPlanetId: () => boolean;
 };
+const INIT_PLANET_ID = -1;
 
-export const useCommunityStore = create<Store>()(set => ({
-  communityId: -1,
+export const useCommunityStore = create<Store>()((set, get) => ({
+  communityId: INIT_PLANET_ID,
   switchCommunity: (id: number) => {
     document.cookie = `communityId=${id}`;
     set(() => ({
       communityId: id,
     }));
+  },
+  isInitPlanetId: () => {
+    return get().communityId === INIT_PLANET_ID;
   },
 }));


### PR DESCRIPTION
### ⛳️ Task

미들웨어와 쿠키 관련 문제였습니다

관련 이슈 [노션페이지 - middleware, 쿠키](https://www.notion.so/depromeet/middleware-1715e5ba5e4642f285900ed5ccd60ad9?pvs=4)에 정리했어요


요약
- 쿠키가 path에 따라 다르게 지정돼서 middleware에서 설정한 행성 라우팅 로직에서 실행되지 않은 문제였어요 
- bottom nav에서 이동할 때 useCommunityStore에 communityId값을 참고해서 이동하게 수정했어요. 
- 안전하게 하려면 middleware에 "/planet"경로에도 "/"과 같은 로직을 적용해야 해요

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference

https://www.notion.so/depromeet/FE-ad792ee8ec4546ba86bafa9222fbfb64?pvs=4

