### PR TITLE
Feat/refact middleware

### DIFF
--- a/src/app/Provider.tsx
+++ b/src/app/Provider.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useRouter } from 'next/navigation';
 import { SessionProvider } from 'next-auth/react';
 import { useState } from 'react';
 
 import { ToastMessageProvider } from '~/components/ToastMessage';
 import initMocks from '~/mocks';
+import { isUnauthorizedError } from '~/utils/auth/error';
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enable') {
   initMocks();
@@ -14,7 +16,19 @@ if (process.env.NEXT_PUBLIC_API_MOCKING === 'enable') {
 
 const Provider = ({ children }: { children: React.ReactNode }) => {
   // TODO: react-query에 필요한 default option 추가하기
-  const [queryClient] = useState(() => new QueryClient());
+  const router = useRouter();
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        queryCache: new QueryCache({
+          onError: error => {
+            if (isUnauthorizedError(error)) {
+              router.push('/auth/signin');
+            }
+          },
+        }),
+      }),
+  );
 
   return (
     <>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,40 +4,17 @@ import { ROOT_API_URL } from '~/api/config/requestUrl';
 import { AUTH_COOKIE_KEYS } from '~/types/auth';
 import { ROUTE_COOKIE_KEYS } from '~/utils/route/route';
 
-// import { UserInfoResponse } from '~/types/user';
-// import { generateCookiesKeyValues } from '~/utils/auth/tokenHandlers';
-
 export const ACCESS_TOKEN_EXPIRE_MARGIN_SECOND = 60;
-
-// Authorization이 필요한 페이지 경로를 저장합니다.
-// const PRIVATE_ROUTES = ['/accounts'];
 
 const getAccessToken = (request: NextRequest) =>
   request.cookies.get(AUTH_COOKIE_KEYS.accessToken)?.value;
 
-// const getAuthRequestHeaders = (request: NextRequest, accessToken: string) => {
-//   const requestHeaders = new Headers(request.headers);
-//   requestHeaders.set('Authorization', `Bearer ${accessToken}`);
-//   return requestHeaders;
-// };
-
-// const logout = (request: NextRequest) => {
-//   // server-side 로그아웃 처리
-//   for (const cookieKey of Object.values(AUTH_COOKIE_KEYS)) {
-//     request.cookies.delete(cookieKey);
-//   }
-// };
-
 const middleware = async (request: NextRequest) => {
   const pathname = request.nextUrl.pathname;
 
-  // 미들웨어 base경로 잠시 해제
   if (pathname === '/') {
     const accessToken = getAccessToken(request);
     if (accessToken) {
-      //TO DO: BE 도메인 정상화 이후 복원
-      //https://github.com/vercel/next.js/discussions/49246 관련 이슈로 privateApi가 아닌 publicApi 사용해야함
-
       const response = await fetch(`${ROOT_API_URL}/user/profile`, {
         method: 'GET',
         headers: new Headers({
@@ -120,63 +97,6 @@ const middleware = async (request: NextRequest) => {
       return NextResponse.redirect(new URL('/auth/signin', request.url));
     }
   }
-
-  //   if (pathname.startsWith('/auth/callback/kakao')) {
-  //     const authCode = request.nextUrl.searchParams.get('code');
-
-  //     if (!authCode) {
-  //       // TODO: 에러 메시지 고도화: 카카오 인증 실패
-  //       return NextResponse.redirect(new URL('/auth/signin',  request.nextUrl.origin));
-  //     }
-
-  //     try {
-  //       const origin = request.nextUrl.origin;
-  //       const authData = await publicApi.postAuthResponse('/auth/login/kakao', {
-  //         authCode,
-  //         redirectUri: `${origin}/auth/callback/kakao`,
-  //       });
-  //       console.log('authData', authData);
-
-  //       // TODO: error처리 고도화: response status혹은 메시지에 따라 if문 수정하기
-  //       if (!authData) {
-  //         // TODO: 에러 메시지 고도화: 로그인 실패
-  //         return NextResponse.redirect(new URL('/auth/signin',  request.nextUrl.origin));
-  //       }
-
-  //       const response = NextResponse.redirect(new URL('/',  request.nextUrl.origin));
-  //       for (const cookie of generateCookiesKeyValues(authData as AuthResponse)) {
-  //         const cookieKey = cookie[0];
-  //         const cookieValue = cookie[1] as string | number;
-  //         response.cookies.set(cookieKey, cookieValue.toString());
-  //       }
-  //       return response;
-  //     } catch (e) {
-  //       // server-side 로그인 실패
-  //       //TODO: server-side fetch CORS 에러 핸들링
-  //       console.log('middleware error', e);
-  //     }
-  //   }
-
-  //   // 인증이 필요한 페이지
-  //   const currentPrivateRoute = PRIVATE_ROUTES.find(route =>
-  //     request.nextUrl.pathname.startsWith(route),
-  //   );
-
-  //   if (currentPrivateRoute) {
-  //     const accessToken = getAccessToken(request);
-
-  //     if (accessToken) {
-  //       const requestHeaders = getAuthRequestHeaders(request, accessToken);
-  //       const response = NextResponse.next({
-  //         request: {
-  //           headers: requestHeaders,
-  //         },
-  //       });
-  //       return response;
-  //     }
-  //     logout(request);
-  //     return NextResponse.redirect(new URL('/auth/signin',  request.nextUrl.origin));
-  //   }
 };
 
 const config = {

--- a/src/modules/Notification/NotificationItem.tsx
+++ b/src/modules/Notification/NotificationItem.tsx
@@ -47,7 +47,7 @@ export const NotificationItem = ({
           <b className={`font-medium ${notificationStatus === 'READ' ? 'text-gray-500' : ''}`}>
             {userDto.fromUserNickname}
           </b>
-          님 이{' '}
+          님이{' '}
           <b className={`font-medium ${notificationStatus === 'READ' ? 'text-gray-500' : ''}`}>
             회원님의 {NOTIFICATION_TYPE[notificationType]}
           </b>

--- a/src/utils/auth/error.ts
+++ b/src/utils/auth/error.ts
@@ -1,6 +1,27 @@
+import { ApiError } from '~/api/config/customError';
+
 export class UserIdNotFoundError extends Error {
   constructor() {
     super('로그인이 필요합니다.');
     this.name = 'UserIdNotFoundError';
   }
 }
+
+export const isUnauthorizedError = (error: unknown): boolean => {
+  if (error instanceof ApiError) {
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      return true;
+    }
+  }
+  // NOTE: redirect가 server side(컴포넌트 외부)에서는 NEXT_REDIRECT 에러를 던지는 것으로 동작합니다. https://github.com/vercel/next.js/issues/42556
+  // interceptor.server.ts의 onResponseErrorServer 함수에서 미로그인시 NEXT_REDIRECT 에러를 던지고 있습니다.
+  if (
+    error &&
+    typeof error === 'object' &&
+    'message' in error &&
+    error['message'] === 'NEXT_REDIRECT'
+  ) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
### ⛳️ Task
미들웨어 코드 정리
react-query 기본 에러 처리에 미인증 redirect 처리 추가
[redirect가 서버사이드(컴포넌트 외부)에서 아직 구현이 안되](https://github.com/vercel/next.js/issues/42556#issuecomment-1328859648)었다고 함. 서버 컴포넌트 렌더링 전에 redirect 처리가 필요하다면 middleware 사용하라고 함(next 제작자 피셜)

https://stackoverflow.com/questions/76191324/next-13-4-error-next-redirect-in-api-routes

따라서 컴포넌트 외부인 route handler, axios interceptor 단에서 redirect 사용시 Error: NEXT_REDIRECT를 던지게됨
우선은 redirect 사용하여 특정된 에러를 던지도록 하고, 에러 상태 고도화시(에러 캐치 부분에서 status code에 접근 가능해지면) 캐치하는 부분에서 미인증 에러 판별하는것이 좋을것 같음
현재 버전: 미인증 에러인지 검증하는 유틸 생성
- 미로그인 판단 기준이 여러 갈래가 되어 isUnauthorizedError 유틸로 묶어 검증해주도록 우선 처리함
- status code
- redirect error
  - interceptor.server에서 미로그인 요청일시 redirect 사용하므로 NEXT_REDIRECT에러를 던지게 되고, 이를 캐치함

띄어쓰기 수정 (알림 띄어쓰기)
### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
