### PR TITLE
og-image태그의 url domain이 localhost로 설정되는 버그 해결

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Inter } from 'next/font/google';
 
 const inter = Inter({ subsets: ['latin'] });
 
+import { ROOT_URL } from '~/api/config/requestUrl';
+
 import Provider from './Provider';
 
 const DEFAULT_OG_TITLE = 'Ding-Dong';
@@ -11,6 +13,7 @@ const DEFAULT_OG_DESC = '딩동으로 새로운 팀원들과 TMI를 공유하고
 const DEFAULT_OG_IMAGE = '/assets/images/default-og-image.png';
 
 export const metadata = {
+  metadataBase: new URL(ROOT_URL),
   title: {
     template: `${DEFAULT_OG_TITLE} / %s `,
     default: DEFAULT_OG_TITLE,
@@ -18,6 +21,7 @@ export const metadata = {
   description: {
     default: DEFAULT_OG_DESC,
   },
+  url: ROOT_URL,
   openGraph: {
     title: DEFAULT_OG_TITLE,
     description: DEFAULT_OG_DESC,


### PR DESCRIPTION
### ⛳️ Task

og-image태그의 url domain이 localhost로 설정되는 버그 해결

### ✍️ Note

RootLayout에 metadataBase 설정

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference

https://nextjs.org/docs/app/api-reference/functions/generate-metadata#metadatabase
