### PR TITLE
Refactor/middleware

### DIFF
--- a/src/api/fetch/privateFetch.ts
+++ b/src/api/fetch/privateFetch.ts
@@ -15,6 +15,7 @@ class PrivateFetch extends PublicFetch {
     return super.common<T>(route, {
       ...(requestInit ?? {}),
       headers: { Authorization: `Bearer ${accessToken}` },
+      credentials: 'include',
     });
   }
   async get<T>(route: string, requestInit?: RequestInit) {

--- a/src/api/fetch/publicFetch.ts
+++ b/src/api/fetch/publicFetch.ts
@@ -1,11 +1,20 @@
 import { ROOT_API_URL } from '../config/requestUrl';
 
 class PublicFetch {
-  async common<T>(route: string, requestInit?: RequestInit): Promise<T> {
+  async common<T>(route: string, requestInit?: RequestInit): Promise<T | null> {
     const response = await fetch(`${ROOT_API_URL}${route}`, {
-      ...(requestInit ?? {}),
+      ...requestInit,
+      headers: new Headers({
+        'content-type': 'application/json',
+        ...(requestInit ? requestInit.headers : {}),
+      }),
+      mode: 'no-cors',
     });
-    return response.json();
+    const data = await response.json();
+    if (!!data && typeof data === 'object' && 'data' in data) {
+      return data.data;
+    }
+    return null;
   }
   async get<T>(route: string, requestInit?: RequestInit) {
     return this.common<T>(route, {

--- a/src/app/auth/callback/kakao/page.tsx
+++ b/src/app/auth/callback/kakao/page.tsx
@@ -12,6 +12,7 @@ const KakaoCallbackPage = () => {
   const code = searchParams.get('code');
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const authData = useLogin(code, {
+    retry: false,
     onSuccess: data => {
       for (const [cookieKey, cookieValue] of generateCookiesKeyValues(data)) {
         document.cookie = `${cookieKey}=${cookieValue}; path=/;`;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,12 @@ export const metadata = {
     description: DEFAULT_OG_DESC,
     images: [DEFAULT_OG_IMAGE],
   },
+  viewport: {
+    width: 'device-width',
+    initialScale: 1,
+    maximumScale: 1,
+    userScalable: 'no',
+  },
 };
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {

--- a/src/components/TopNavigation/TopNavigationWrapper.tsx
+++ b/src/components/TopNavigation/TopNavigationWrapper.tsx
@@ -15,7 +15,7 @@ export const TopNavigationWrapper = ({
   const borderBottomStyle = bottomBorderColor ? `border-b-${bottomBorderColor} border-b-[1px]` : '';
   return (
     <nav
-      className={`fixed left-0 right-0 top-0 z-top1 flex h-t-nav w-full items-center justify-between px-layout-sm ${borderBottomStyle} ${bgColor}`}
+      className={`fixed left-0 right-0 top-0 z-top1 mx-auto flex h-t-nav w-full max-w-[420px] items-center justify-between px-layout-sm ${borderBottomStyle} ${bgColor}`}
     >
       {children}
     </nav>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,12 @@
 import { URLSearchParams } from 'next/dist/compiled/@edge-runtime/primitives/url';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { ROOT_API_URL } from '~/api/config/requestUrl';
-import { AUTH_COOKIE_KEYS } from '~/types/auth';
+import { AUTH_COOKIE_KEYS, AuthResponse } from '~/types/auth';
 import { ROUTE_COOKIE_KEYS } from '~/utils/route/route';
 
+import { publicFetch } from './api/fetch/publicFetch';
+import { UserInfoResponse } from './types/user';
+import { generateCookiesKeyValues } from './utils/auth/tokenHandlers';
 import { getFetch, postFetch } from './utils/fetch';
 
 export const ACCESS_TOKEN_EXPIRE_MARGIN_SECOND = 60;
@@ -70,21 +72,13 @@ const middleware = async (request: NextRequest) => {
       const accessToken = getAccessToken(request);
 
       if (accessToken) {
-        const response = await fetch(`${ROOT_API_URL}/user/profile`, {
-          method: 'GET',
-          headers: new Headers({
-            'content-type': 'application/json',
-            Authorization: `Bearer ${accessToken}`,
-          }),
-          mode: 'no-cors',
+        const data = await publicFetch.get<UserInfoResponse>('/user/profile', {
+          headers: { Authorization: `Bearer ${accessToken}` },
           credentials: 'include',
         });
-        if (!response.ok) {
-          return NextResponse.redirect(new URL('/auth/signin', request.url));
-        }
-        const data = await response.json();
+        if (!data) return NextResponse.redirect(new URL('/auth/signin', request.url));
 
-        const { communityIds } = data.data.userProfileDto;
+        const { communityIds } = data.userProfileDto;
         const currentCommunityId = request.cookies.get('communityId')?.value;
 
         if (currentCommunityId) {
@@ -98,6 +92,32 @@ const middleware = async (request: NextRequest) => {
       return NextResponse.redirect(new URL('/auth/signin', request.url));
     } catch (e) {
       return NextResponse.redirect(new URL('/auth/signin', request.url));
+    }
+  }
+  if (pathname.startsWith('/auth/callback/kakao')) {
+    const authCode = request.nextUrl.searchParams.get('code');
+    if (!authCode) {
+      return NextResponse.redirect(new URL('/auth/signin', request.url));
+    }
+    try {
+      const origin = request.nextUrl.origin;
+      const authData = await publicFetch.post<AuthResponse>('/auth/login/kakao', {
+        body: JSON.stringify({ authCode, redirectUri: `${origin}/auth/callback/kakao` }),
+      });
+
+      if (!authData) {
+        throw new Error('authData is null');
+      }
+
+      const res = NextResponse.redirect(new URL('/', request.url));
+      for (const cookie of generateCookiesKeyValues(authData as AuthResponse)) {
+        const cookieKey = cookie[0];
+        const cookieValue = cookie[1] as string | number;
+        res.cookies.set(cookieKey, cookieValue.toString());
+      }
+      return res;
+    } catch (e) {
+      console.log(e);
     }
   }
 };


### PR DESCRIPTION
### ⛳️ Task
fetch 모듈의 설정을 수정했어요.
- content-type과 mode를 추가했습니다.
- data를 파싱해서 반환하도록 했습니다.

스타일 수정했어요.
- 모바일에서 확대되지 않도록 meta tag 설정 추가
- 헤더 pc에서 퍼지지 않도록 최대폭 지정

서버사이드 로그인 추가했어요.
- middleware에 kakao callback url을 캐치하여 로그인 처리하는 로직 추가
- 실패시 클라이언트 로그인 페이지로 라우팅되도록 처리
### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
