### PR TITLE
refactor: 403일 때는 토큰 발급 로직 실행 안되게 수정

### DIFF
--- a/src/api/config/interceptor.client.ts
+++ b/src/api/config/interceptor.client.ts
@@ -35,7 +35,7 @@ export const onResponseErrorClient = async (
       const data = error.response.data;
       const { success, statusCode, errorCode, reason } = data;
 
-      if (error.response.status === 401 || error.response.status === 403) {
+      if (error.response.status === 401) {
         try {
           const auth = getAuthTokensByCookie(document.cookie);
           const validTokenResponse = await getAccessTokenClient(auth);
@@ -63,6 +63,7 @@ export const onResponseErrorClient = async (
           }
         } catch (e) {
           // client-side 로그아웃 처리
+          console.log(e);
           redirect('/auth/signin');
           return Promise.reject(e);
         }

--- a/src/api/config/interceptor.server.ts
+++ b/src/api/config/interceptor.server.ts
@@ -37,7 +37,7 @@ export const onResponseErrorServer = async (
       const data = error.response.data;
       const { success, statusCode, errorCode, reason } = data;
 
-      if (error.response.status === 401 || error.response.status === 403) {
+      if (error.response.status === 401) {
         try {
           const cookieStore = cookies();
           const refreshToken = cookieStore.get(AUTH_COOKIE_KEYS.refreshToken)?.value;

--- a/src/utils/auth/error.ts
+++ b/src/utils/auth/error.ts
@@ -9,7 +9,7 @@ export class UserIdNotFoundError extends Error {
 
 export const isUnauthorizedError = (error: unknown): boolean => {
   if (error instanceof ApiError) {
-    if (error.statusCode === 401 || error.statusCode === 403) {
+    if (error.statusCode === 401) {
       return true;
     }
   }


### PR DESCRIPTION
### ⛳️ Task

axios interceptor에서 401(인증)에러 일때만 토큰 갱신 로직이 실행되고, 403(인가)에러 일 때는 실행되지 않게 수정했어요

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
