### PR TITLE
Change param to header of refresh token issue api

### DIFF
--- a/src/api/domain/auth.api.client.ts
+++ b/src/api/domain/auth.api.client.ts
@@ -26,4 +26,6 @@ export const useLogin = (code: string | null, options?: UseQueryOptions<AuthResp
 };
 
 export const reissue = async (refreshToken: string) =>
-  publicApi.get<AuthResponse>('/auth/login/reissue', { params: { REFRESH_TOKEN: refreshToken } });
+  publicApi.get<AuthResponse>('/auth/login/reissue', {
+    headers: { 'REFRESH-TOKEN': refreshToken },
+  });


### PR DESCRIPTION
### ⛳️ Task

- api에 맞춰 refresh token 재발급 param을 header로 옮깁니다.

### Up to Next
BE에서 배포 후 머지합니다.

### 📎 Reference
[slack](https://depromeet13th.slack.com/archives/C0515CGG9H8/p1689867313773059?thread_ts=1689865098.267469&cid=C0515CGG9H8)