### PR TITLE
토스트 알람 최대 길이 수정 및 최대 길이 tailwind 변수 관리 설정

### DIFF
--- a/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/src/components/BottomNavigation/BottomNavigation.tsx
@@ -58,7 +58,7 @@ export const BottomNavigation = () => {
 
   return (
     <nav className="fixed bottom-0 left-0 flex w-full justify-center">
-      <ul className="flex h-b-nav w-full max-w-[420px] items-center justify-evenly border-t border-grey-100 bg-white">
+      <ul className="flex h-b-nav w-full max-w-content items-center justify-evenly border-t border-grey-100 bg-white">
         <li>
           <button onClick={onClickHome}>
             <HomeIcon className={getSvgColor('/planet')} />

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -34,7 +34,7 @@ const BottomSheet = ({ children, isOpen, onClose }: BottomSheetProps) => {
             <motion.div
               key="sheet"
               {...SheetVariants}
-              className=" fixed bottom-0 z-top1 flex max-h-[calc(100vh-212px)] w-full max-w-[420px] translate-x-1/2 flex-col rounded-t-[20px] bg-white px-5 py-6"
+              className=" fixed bottom-0 z-top1 flex max-h-[calc(100vh-212px)] w-full max-w-content translate-x-1/2 flex-col rounded-t-[20px] bg-white px-5 py-6"
             >
               {children}
             </motion.div>

--- a/src/components/ToastMessage/ToastMessage.tsx
+++ b/src/components/ToastMessage/ToastMessage.tsx
@@ -10,5 +10,15 @@ const colors: Record<ToastMessageType, string> = {
 };
 
 export const ToastMessage = ({ message, type }: ToastMessageProps) => {
-  return <div className={tw('rounded-[12px]  p-16pxr text-b2', colors[type])}>{message}</div>;
+  return (
+    <div
+      className={tw(
+        'absolute left-1/2 top-60pxr w-[calc(100vw-40px)] max-w-[calc(theme(maxWidth.content)-40px)] -translate-x-1/2 transform',
+        'rounded-[12px] p-16pxr text-b2',
+        colors[type],
+      )}
+    >
+      {message}
+    </div>
+  );
 };

--- a/src/components/ToastMessage/ToastMessageProvider.tsx
+++ b/src/components/ToastMessage/ToastMessageProvider.tsx
@@ -9,23 +9,22 @@ export const ToastMessageProvider = () => {
   const { toastMessageList } = useToastMessageStore();
   return (
     <Portal documentId="toast-portal">
-      <div className="fixed left-0 right-0 top-0 z-toast w-full px-layout-sm">
-        <AnimatePresence initial={false}>
-          {toastMessageList.map(({ toastId, message, type }) => {
-            return (
+      <div className="fixed left-0 right-0 top-0 z-toast px-layout-sm">
+        <div className="relative w-full">
+          <AnimatePresence initial={false}>
+            {toastMessageList.map(({ toastId, message, type }) => (
               <motion.div
                 key={toastId}
                 initial={{ y: -200 }}
                 animate={{ y: 0 }}
                 exit={{ y: -200 }}
                 transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
-                className="absolute top-60pxr w-[calc(100vw-40px)]"
               >
                 <ToastMessage type={type} message={message} />
               </motion.div>
-            );
-          })}
-        </AnimatePresence>
+            ))}
+          </AnimatePresence>
+        </div>
       </div>
     </Portal>
   );

--- a/src/components/TopNavigation/TopNavigationWrapper.tsx
+++ b/src/components/TopNavigation/TopNavigationWrapper.tsx
@@ -15,7 +15,7 @@ export const TopNavigationWrapper = ({
   const borderBottomStyle = bottomBorderColor ? `border-b-${bottomBorderColor} border-b-[1px]` : '';
   return (
     <nav
-      className={`fixed left-0 right-0 top-0 z-top2 mx-auto flex h-t-nav w-full max-w-[420px] items-center justify-between px-layout-sm ${borderBottomStyle} ${bgColor}`}
+      className={`fixed left-0 right-0 top-0 z-top2 mx-auto flex h-t-nav w-full max-w-content items-center justify-between px-layout-sm ${borderBottomStyle} ${bgColor}`}
     >
       {children}
     </nav>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -117,6 +117,9 @@ module.exports = {
         'none-t-nav': '-50px',
         ...declarePxr(),
       },
+      maxWidth: {
+        content: '420px',
+      },
       // TODO: 아직 폰트가 정해지지 않아 기본 값으로 넣어두었습니다. 폰트 지정 후 수정이 필요합니다.
       fontFamily: {
         Pretendard: ['Pretendard Variable', 'Pretendard'],


### PR DESCRIPTION
### ⛳️ Task

토스트 알람 최대 길이 수정
- 바텀네비와 탑네비처럼 최대 길이 420px 설정
최대 길이 tailwind 변수 관리 설정
- 420px -> content변수로 설정
- ex. max-w-content

### ✍️ Note

### ⚡️ Test

### 📸 Screenshot

| AS-IS | TO-BE |
| ----- | ----- |
|       |       |

### 📎 Reference
