### PR TITLE
Prevent user creating id card on ding dong planet

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,6 +7,7 @@ import { AUTH_COOKIE_KEYS } from '~/types/auth';
 import { ROUTE_COOKIE_KEYS } from '~/utils/route/route';
 
 import { getFetch, postFetch } from './utils/fetch';
+import { DINGDONG_PLANET } from './utils/variable';
 
 export const ACCESS_TOKEN_EXPIRE_MARGIN_SECOND = 60;
 
@@ -103,6 +104,12 @@ const middleware = async (request: NextRequest) => {
     } catch (e) {
       return NextResponse.redirect(new URL('/auth/signin', request.url));
     }
+  }
+
+  if (pathname === `/planet/${DINGDONG_PLANET.DINGDONG_PLANET_ID}/id-card/create`) {
+    return NextResponse.redirect(
+      new URL(`/planet/${DINGDONG_PLANET.DINGDONG_PLANET_ID}`, request.url),
+    );
   }
 };
 

--- a/src/modules/PlanetSelector/PlanetSelector.client.tsx
+++ b/src/modules/PlanetSelector/PlanetSelector.client.tsx
@@ -66,7 +66,10 @@ export const PlanetSelector = () => {
 
   return (
     <div className="w-full">
-      <div className="flex w-full items-center gap-8pxr" onClick={bottomSheetHandlers.onOpen}>
+      <div
+        className="flex w-full cursor-pointer items-center gap-8pxr"
+        onClick={bottomSheetHandlers.onOpen}
+      >
         <p className="mix-w-[70%] overflow-hidden text-ellipsis whitespace-nowrap text-h1 text-grey-800">
           {defaultCommunity?.title}
         </p>


### PR DESCRIPTION
### ⛳️ Task

- 딩동 행성의 주민증 생성을 막기 위해 `/planet/1/id-card/create` url로 넘어올 시 ding dong 행성으로 보냅니다.
- 행성 전환 시 `pointer: cursor` 로 스타일을 수정합니다.