### PR TITLE
Add backdrop on bell

### DIFF
--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { BellMessage } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessage';
+import { BellMessages } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages';
 
 import { BellButton } from './Button/BellButton';
 
@@ -27,7 +27,7 @@ export const Bell = ({ isMyIdCard, bellType }: BellProps) => {
           {isMessageOpen && (
             <>
               {/*backdrop*/}
-              <BellMessage activeBellType="rice" />
+              <BellMessages activeBellType="rice" />
             </>
           )}
           <BellButton

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { AnimatePresence, motion } from 'framer-motion';
 import { useRef, useState } from 'react';
 
 import { BellMessages } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages';
@@ -38,9 +39,11 @@ export const Bell = ({ isMyIdCard, bellType, nickname: nicknameToReceiveMsg }: B
           <BellButton bellType="bell" onClick={onMyBellClick} />
         ) : (
           <>
-            {isMessageOpen && (
-              <BellMessages activeBellType="rice" onMessageClick={onMessageClick} />
-            )}
+            <AnimatePresence>
+              {isMessageOpen && (
+                <BellMessages activeBellType="rice" onMessageClick={onMessageClick} />
+              )}
+            </AnimatePresence>
             <BellButton
               bellType={bellType || 'bell'}
               onClick={onOtherBellClick}
@@ -50,9 +53,18 @@ export const Bell = ({ isMyIdCard, bellType, nickname: nicknameToReceiveMsg }: B
           </>
         )}
       </div>
-      {isMessageOpen && (
-        <div ref={backdropRef} className="fixed left-0 top-0 z-top1 h-full w-full bg-black/50" />
-      )}
+      <AnimatePresence>
+        {isMessageOpen && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.4 }}
+            ref={backdropRef}
+            className="fixed left-0 top-0 z-top1 h-full w-full bg-black/50"
+          />
+        )}
+      </AnimatePresence>
     </>
   );
 };

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+'use client';
+import { useRef, useState } from 'react';
 
 import { BellMessages } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages';
 import { useToastMessageStore } from '~/stores/toastMessage.store';
@@ -15,6 +16,7 @@ type BellProps = {
 
 export const Bell = ({ isMyIdCard, bellType, nickname: nicknameToReceiveMsg }: BellProps) => {
   const [isMessageOpen, setIsMessageOpen] = useState(false);
+  const backdropRef = useRef(null);
   const { successToast } = useToastMessageStore();
   const onMyBellClick = () => {
     // bottomsheet open
@@ -30,25 +32,27 @@ export const Bell = ({ isMyIdCard, bellType, nickname: nicknameToReceiveMsg }: B
   };
 
   return (
-    <div className="fixed bottom-60pxr right-20pxr flex flex-col items-end ">
-      {isMyIdCard ? (
-        <BellButton bellType="bell" onClick={onMyBellClick} />
-      ) : (
-        <>
-          {isMessageOpen && (
-            <>
-              {/*backdrop*/}
+    <>
+      <div className="fixed bottom-60pxr right-20pxr z-modal flex flex-col items-end ">
+        {isMyIdCard ? (
+          <BellButton bellType="bell" onClick={onMyBellClick} />
+        ) : (
+          <>
+            {isMessageOpen && (
               <BellMessages activeBellType="rice" onMessageClick={onMessageClick} />
-            </>
-          )}
-          <BellButton
-            bellType={bellType || 'bell'}
-            onClick={onOtherBellClick}
-            isOpen={isMessageOpen}
-            className="mt-16pxr"
-          />
-        </>
+            )}
+            <BellButton
+              bellType={bellType || 'bell'}
+              onClick={onOtherBellClick}
+              isOpen={isMessageOpen}
+              className="mt-16pxr"
+            />
+          </>
+        )}
+      </div>
+      {isMessageOpen && (
+        <div ref={backdropRef} className="fixed left-0 top-0 z-top1 h-full w-full bg-black/50" />
       )}
-    </div>
+    </>
   );
 };

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client.tsx
@@ -1,21 +1,32 @@
 import { useState } from 'react';
 
 import { BellMessages } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages';
+import { useToastMessageStore } from '~/stores/toastMessage.store';
+import { IdCardDetailModel } from '~/types/idCard';
 
 import { BellButton } from './Button/BellButton';
 
+type BellType = 'celebration' | 'eye' | 'heart' | 'rice';
 type BellProps = {
   isMyIdCard: boolean;
   bellType?: 'celebration' | 'eye' | 'heart' | 'rice';
+  nickname: IdCardDetailModel['nickname'];
 };
 
-export const Bell = ({ isMyIdCard, bellType }: BellProps) => {
+export const Bell = ({ isMyIdCard, bellType, nickname: nicknameToReceiveMsg }: BellProps) => {
   const [isMessageOpen, setIsMessageOpen] = useState(false);
+  const { successToast } = useToastMessageStore();
   const onMyBellClick = () => {
     // bottomsheet open
   };
   const onOtherBellClick = () => {
     setIsMessageOpen(!isMessageOpen);
+  };
+  const onMessageClick = (bellType: BellType) => {
+    // TODO: bellType post api -> 성공할 경우 detail 정보 invalidate query를 이용해서 새로운 정보 받아오기
+    console.log({ bellType }); // api 붙이면서 함께 삭제 예정
+    setIsMessageOpen(!isMessageOpen);
+    successToast(`${nicknameToReceiveMsg}에게 성공적으로 딩동을 보냈어요!`);
   };
 
   return (
@@ -27,7 +38,7 @@ export const Bell = ({ isMyIdCard, bellType }: BellProps) => {
           {isMessageOpen && (
             <>
               {/*backdrop*/}
-              <BellMessages activeBellType="rice" />
+              <BellMessages activeBellType="rice" onMessageClick={onMessageClick} />
             </>
           )}
           <BellButton

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.stories.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
-import { Bell } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell';
+import { Bell } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client';
 
 const meta: Meta<typeof Bell> = {
   title: 'components/Bell',

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.tsx
@@ -33,10 +33,9 @@ export const Bell = ({ isMyIdCard, bellType }: BellProps) => {
           <BellButton
             bellType={bellType || 'bell'}
             onClick={onOtherBellClick}
-            isClose={isMessageOpen}
+            isOpen={isMessageOpen}
             className="mt-16pxr"
           />
-          {/*BellCloseButton*/}
         </>
       )}
     </div>

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Button/BellButton.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Button/BellButton.tsx
@@ -32,6 +32,7 @@ export const BellButton = ({ className, bellType, onClick, isOpen, ...props }: B
     )}
     onClick={onClick}
     {...props}
+    type="button"
   >
     {isOpen ? <BellCloseIcon /> : bellIconMap[bellType]}
   </button>

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Button/BellButton.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Button/BellButton.tsx
@@ -22,15 +22,9 @@ const bellIconMap: Record<BellIconType, ReactNode> = {
 type BellButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   bellType: BellIconType;
   onClick?: () => void;
-  isClose?: boolean;
+  isOpen?: boolean;
 };
-export const BellButton = ({
-  className,
-  bellType,
-  onClick,
-  isClose,
-  ...props
-}: BellButtonProps) => (
+export const BellButton = ({ className, bellType, onClick, isOpen, ...props }: BellButtonProps) => (
   <button
     className={twMerge(
       'border-2pxr flex h-56pxr w-56pxr items-center justify-center rounded-full border-[#DFE3FF] bg-[#E7EAFF]',
@@ -39,6 +33,6 @@ export const BellButton = ({
     onClick={onClick}
     {...props}
   >
-    {isClose ? <BellCloseIcon /> : bellIconMap[bellType]}
+    {isOpen ? <BellCloseIcon /> : bellIconMap[bellType]}
   </button>
 );

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages.tsx
@@ -33,7 +33,7 @@ const bellMessages: BellMessagesType = [
   },
 ];
 
-export const BellMessage = ({ className, activeBellType }: BellMessageProps) => (
+export const BellMessages = ({ className, activeBellType }: BellMessageProps) => (
   <div className={twMerge('flex flex-col gap-12pxr', className)}>
     {bellMessages.map(({ icon, text, id }) => {
       return (

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages.tsx
@@ -7,6 +7,7 @@ type BellType = 'celebration' | 'eye' | 'heart' | 'rice';
 type BellMessageProps = {
   className?: string;
   activeBellType: BellType;
+  onMessageClick: (bellType: BellType) => void;
 };
 
 type BellMessagesType = { icon: ReactNode; text: string; id: BellType }[];
@@ -33,7 +34,7 @@ const bellMessages: BellMessagesType = [
   },
 ];
 
-export const BellMessages = ({ className, activeBellType }: BellMessageProps) => (
+export const BellMessages = ({ className, activeBellType, onMessageClick }: BellMessageProps) => (
   <div className={twMerge('flex flex-col gap-12pxr', className)}>
     {bellMessages.map(({ icon, text, id }) => {
       return (
@@ -43,6 +44,7 @@ export const BellMessages = ({ className, activeBellType }: BellMessageProps) =>
             'flex w-180pxr items-center justify-between rounded-[44px] bg-[#E7EAFF] px-16pxr py-7pxr text-15pxr font-bold',
             id === activeBellType && 'bg-[#8C82FF]',
           )}
+          onClick={() => onMessageClick(id)}
         >
           {icon}
           <div>{text}</div>

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Message/BellMessages.tsx
@@ -1,3 +1,4 @@
+import { motion } from 'framer-motion';
 import { ReactNode } from 'react';
 
 import { CelebrationIcon, EyeIcon, HeartExchangeIcon, RiceIcon } from '~/components/Icon';
@@ -34,12 +35,49 @@ const bellMessages: BellMessagesType = [
   },
 ];
 
+const containerVariants = {
+  hidden: {
+    opacity: 0,
+  },
+  visible: {
+    opacity: 1,
+    transition: {
+      when: 'beforeChildren',
+      staggerChildren: 0.01,
+      staggerDirection: -1,
+    },
+  },
+  closed: {
+    opacity: 0,
+    transition: {
+      when: 'afterChildren',
+      staggerChildren: 0.01,
+      staggerDirection: 1,
+    },
+  },
+};
+
+const messageVariants = {
+  hidden: { opacity: 0, y: -50 },
+  visible: { opacity: 1, y: 0 },
+  closed: { opacity: 0, y: -50 },
+};
+
 export const BellMessages = ({ className, activeBellType, onMessageClick }: BellMessageProps) => (
-  <div className={twMerge('flex flex-col gap-12pxr', className)}>
+  <motion.ul
+    variants={containerVariants}
+    initial="hidden"
+    animate="visible"
+    exit="closed"
+    className={twMerge('flex flex-col gap-12pxr', className)}
+  >
     {bellMessages.map(({ icon, text, id }) => {
       return (
-        <div
+        <motion.li
           key={id}
+          variants={messageVariants}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
           className={twMerge(
             'flex w-180pxr items-center justify-between rounded-[44px] bg-[#E7EAFF] px-16pxr py-7pxr text-15pxr font-bold',
             id === activeBellType && 'bg-[#8C82FF]',
@@ -48,8 +86,8 @@ export const BellMessages = ({ className, activeBellType, onMessageClick }: Bell
         >
           {icon}
           <div>{text}</div>
-        </div>
+        </motion.li>
       );
     })}
-  </div>
+  </motion.ul>
 );

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/IdCardDetail/IdCardDetail.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/IdCardDetail/IdCardDetail.tsx
@@ -72,7 +72,7 @@ const IdCardDetailComponent = ({ idCardId, communityId }: IdCardDetailProps) => 
           ))}
         </div>
       </div>
-      <Bell isMyIdCard={isMyIdCard} bellType="rice" />
+      <Bell isMyIdCard={isMyIdCard} nickname={idCardDetailsDto.nickname} bellType="rice" />
     </>
   );
 };

--- a/src/app/planet/[communityId]/id-card/[idCardId]/components/IdCardDetail/IdCardDetail.tsx
+++ b/src/app/planet/[communityId]/id-card/[idCardId]/components/IdCardDetail/IdCardDetail.tsx
@@ -4,7 +4,7 @@ import { Suspense } from 'react';
 
 import { useGetIdCardDetail } from '~/api/domain/idCard.api';
 import { useGetUserInfo } from '~/api/domain/user.api';
-import { Bell } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell';
+import { Bell } from '~/app/planet/[communityId]/id-card/[idCardId]/components/Bell/Bell.client';
 import RetryErrorBoundary from '~/components/ErrorBoundary/RetryErrorBoundary.client';
 import { TopNavigation } from '~/components/TopNavigation';
 import { Intro, KeywordContentCard } from '~/modules/IdCardDetail';


### PR DESCRIPTION
### ⛳️ Task

- prop 이름을 변경하고 client prefix를 추가합니다.
- bell message를 누른 후 toast가 나오도록 추가합니다.
- backdrop을 추가합니다.
- 애니메이션을 추가합니다.

### ✍️ Note

- [ ] api 추가 예정
- [ ] api에 맞게 컴포넌트 이름 변경 예정
- [ ] 디자인에 맞추어 아이콘 수정 예정

### ⚡️ Test

`pnpm storybook` + `pnpm msw`로 http://localhost:3000/planet/11/id-card/1 에서 보실 수 있습니다.

### 📸 Screenshot

![Sep-08-2023 00-20-17](https://github.com/depromeet/Ding-dong-fe/assets/55529617/46bef4d5-4e7f-4f3d-becd-b13d54dfc85e)

### 📎 Reference
[framer motion](https://www.framer.com/motion/)
[Figma](https://www.figma.com/file/h0adZ1H8szR3zpNThEMfm2/DD-_-WIRE-FRAME-(Copy)?type=design&node-id=3268-25220&mode=design&t=Th7sl1TPmkbyplV8-4)